### PR TITLE
iterator: use the header

### DIFF
--- a/src/libqhullcpp/QhullIterator.h
+++ b/src/libqhullcpp/QhullIterator.h
@@ -14,10 +14,9 @@ extern "C" {
 }
 
 #include <assert.h>
+#include <iterator>
 #include <string>
 #include <vector>
-//! Avoid dependence on <iterator>
-namespace std { struct bidirectional_iterator_tag; struct random_access_iterator_tag; }
 
 namespace orgQhull {
 

--- a/src/libqhullcpp/QhullLinkedList.h
+++ b/src/libqhullcpp/QhullLinkedList.h
@@ -9,10 +9,7 @@
 #ifndef QHULLLINKEDLIST_H
 #define QHULLLINKEDLIST_H
 
-namespace std {
-    struct bidirectional_iterator_tag;
-    struct random_access_iterator_tag;
-}//std
+#include <iterator>
 
 #include "QhullError.h"
 extern "C" {


### PR DESCRIPTION
Standard libraries are doing funky things with inline namespaces which
make these declarations impossible to get right. Just include the
header.

---
This appears on OS X with the libc++ library that Xcode now compiles against by default.