### PR TITLE
Make C headers safe for C++ inclusion.

### DIFF
--- a/src/libqhull_r/geom_r.h
+++ b/src/libqhull_r/geom_r.h
@@ -98,6 +98,10 @@
 
 /*============= prototypes in alphabetical order, infrequent at end ======= */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void    qh_backnormal(qhT *qh, realT **rows, int numrow, int numcol, boolT sign, coordT *normal, boolT *nearzero);
 void    qh_distplane(qhT *qh, pointT *point, facetT *facet, realT *dist);
 facetT *qh_findbest(qhT *qh, pointT *point, facetT *startfacet,
@@ -169,6 +173,10 @@ boolT   qh_sethalfspace(qhT *qh, int dim, coordT *coords, coordT **nextp,
               coordT *normal, coordT *offset, coordT *feasible);
 coordT *qh_sethalfspace_all(qhT *qh, int dim, int count, coordT *halfspaces, pointT *feasible);
 pointT *qh_voronoi_center(qhT *qh, int dim, setT *points);
+
+#ifdef __cplusplus
+} /* extern "C"*/
+#endif
 
 #endif /* qhDEFgeom */
 

--- a/src/libqhull_r/io_r.h
+++ b/src/libqhull_r/io_r.h
@@ -77,6 +77,10 @@ typedef void (*printvridgeT)(qhT *qh, FILE *fp, vertexT *vertex, vertexT *vertex
 
 /*============== -prototypes in alphabetical order =========*/
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void    qh_dfacet(qhT *qh, unsigned id);
 void    qh_dvertex(qhT *qh, unsigned id);
 int     qh_compare_facetarea(const void *p1, const void *p2);
@@ -155,5 +159,9 @@ coordT *qh_readpoints(qhT *qh, int *numpoints, int *dimension, boolT *ismalloc);
 void    qh_setfeasible(qhT *qh, int dim);
 boolT   qh_skipfacet(qhT *qh, facetT *facet);
 char   *qh_skipfilename(qhT *qh, char *filename);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* qhDEFio */

--- a/src/libqhull_r/libqhull_r.h
+++ b/src/libqhull_r/libqhull_r.h
@@ -1017,6 +1017,10 @@ struct qhT {
 */
 #define FOREACHvertex_i_(qh, vertices) FOREACHsetelement_i_(qh, vertexT, vertices,vertex)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /********* -libqhull_r.c prototypes (duplicated from qhull_ra.h) **********************/
 
 void    qh_qhull(qhT *qh);
@@ -1122,5 +1126,9 @@ void    qh_errexit_rbox(qhT *qh, int exitcode);
 
 void    qh_collectstatistics(qhT *qh);
 void    qh_printallstatistics(qhT *qh, FILE *fp, const char *string);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* qhDEFlibqhull */

--- a/src/libqhull_r/mem_r.h
+++ b/src/libqhull_r/mem_r.h
@@ -211,6 +211,10 @@ struct qhmemT {               /* global memory management variables */
 
 /*=============== prototypes in alphabetical order ============*/
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void *qh_memalloc(qhT *qh, int insize);
 void qh_memcheck(qhT *qh);
 void qh_memfree(qhT *qh, void *object, int insize);
@@ -222,5 +226,9 @@ void qh_memsetup(qhT *qh);
 void qh_memsize(qhT *qh, int size);
 void qh_memstatistics(qhT *qh, FILE *fp);
 void qh_memtotal(qhT *qh, int *totlong, int *curlong, int *totshort, int *curshort, int *maxlong, int *totbuffer);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* qhDEFmem */

--- a/src/libqhull_r/merge_r.h
+++ b/src/libqhull_r/merge_r.h
@@ -113,6 +113,10 @@ struct mergeT {         /* initialize in qh_appendmergeset */
 
 /*============ prototypes in alphabetical order after pre/postmerge =======*/
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void    qh_premerge(qhT *qh, vertexT *apex, realT maxcentrum, realT maxangle);
 void    qh_postmerge(qhT *qh, const char *reason, realT maxcentrum, realT maxangle,
              boolT vneighbors);
@@ -174,5 +178,9 @@ void    qh_updatetested(qhT *qh, facetT *facet1, facetT *facet2);
 setT   *qh_vertexridges(qhT *qh, vertexT *vertex);
 void    qh_vertexridges_facet(qhT *qh, vertexT *vertex, facetT *facet, setT **ridges);
 void    qh_willdelete(qhT *qh, facetT *facet, facetT *replace);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* qhDEFmerge */

--- a/src/libqhull_r/poly_r.h
+++ b/src/libqhull_r/poly_r.h
@@ -207,6 +207,10 @@
 
 /*=============== prototypes poly_r.c in alphabetical order ================*/
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void    qh_appendfacet(qhT *qh, facetT *facet);
 void    qh_appendvertex(qhT *qh, vertexT *vertex);
 void    qh_attachnewfacets(qhT *qh /* qh.visible_list, qh.newfacet_list */);
@@ -292,5 +296,8 @@ setT   *qh_vertexintersect_new(qhT *qh, setT *vertexsetA,setT *vertexsetB);
 void    qh_vertexneighbors(qhT *qh /*qh.facet_list*/);
 boolT   qh_vertexsubset(setT *vertexsetA, setT *vertexsetB);
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* qhDEFpoly */

--- a/src/libqhull_r/qhull_ra.h
+++ b/src/libqhull_r/qhull_ra.h
@@ -109,6 +109,10 @@ inline void qhullUnused(T &x) { (void)x; }
 #  define QHULL_UNUSED(x) (void)x;
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /***** -libqhull_r.c prototypes (alphabetical after qhull) ********************/
 
 void    qh_qhull(qhT *qh);
@@ -146,5 +150,9 @@ void    qh_allstatG(qhT *qh);
 void    qh_allstatH(qhT *qh);
 void    qh_freebuffers(qhT *qh);
 void    qh_initbuffers(qhT *qh, coordT *points, int numpoints, int dim, boolT ismalloc);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* qhDEFqhulla */

--- a/src/libqhull_r/qset_r.h
+++ b/src/libqhull_r/qset_r.h
@@ -452,6 +452,10 @@ struct setT {
 
 /*======= prototypes in alphabetical order ============*/
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void  qh_setaddsorted(qhT *qh, setT **setp, void *elem);
 void  qh_setaddnth(qhT *qh, setT **setp, int nth, void *newelem);
 void  qh_setappend(qhT *qh, setT **setp, void *elem);
@@ -491,5 +495,8 @@ void  qh_settruncate(qhT *qh, setT *set, int size);
 int   qh_setunique(qhT *qh, setT **set, void *elem);
 void  qh_setzero(qhT *qh, setT *set, int idx, int size);
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* qhDEFset */

--- a/src/libqhull_r/random_r.h
+++ b/src/libqhull_r/random_r.h
@@ -18,6 +18,9 @@
 
 /*============= prototypes in alphabetical order ======= */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 int     qh_argv_to_command(int argc, char *argv[], char* command, int max_size);
 int     qh_argv_to_command_size(int argc, char *argv[]);
@@ -27,6 +30,10 @@ realT   qh_randomfactor(qhT *qh, realT scale, realT offset);
 void    qh_randommatrix(qhT *qh, realT *buffer, int dim, realT **row);
 int     qh_strtol(const char *s, char **endp);
 double  qh_strtod(const char *s, char **endp);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* qhDEFrandom */
 

--- a/src/libqhull_r/stat_r.h
+++ b/src/libqhull_r/stat_r.h
@@ -501,6 +501,10 @@ struct qhstatT {
 
 /*========== function prototypes ===========*/
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void    qh_allstatA(qhT *qh);
 void    qh_allstatB(qhT *qh);
 void    qh_allstatC(qhT *qh);
@@ -521,5 +525,9 @@ void    qh_printstatistics(qhT *qh, FILE *fp, const char *string);
 void    qh_printstatlevel(qhT *qh, FILE *fp, int id);
 void    qh_printstats(qhT *qh, FILE *fp, int idx, int *nextindex);
 realT   qh_stddev(int num, realT tot, realT tot2, realT *ave);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif   /* qhDEFstat */

--- a/src/libqhullcpp/Coordinates.h
+++ b/src/libqhullcpp/Coordinates.h
@@ -9,9 +9,7 @@
 #ifndef QHCOORDINATES_H
 #define QHCOORDINATES_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 #include "libqhullcpp/QhullError.h"
 #include "libqhullcpp/QhullIterator.h"
 

--- a/src/libqhullcpp/PointCoordinates.h
+++ b/src/libqhullcpp/PointCoordinates.h
@@ -9,9 +9,7 @@
 #ifndef QHPOINTCOORDINATES_H
 #define QHPOINTCOORDINATES_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 #include "libqhullcpp/QhullPoints.h"
 #include "libqhullcpp/Coordinates.h"
 

--- a/src/libqhullcpp/QhullFacet.h
+++ b/src/libqhullcpp/QhullFacet.h
@@ -9,9 +9,7 @@
 #ifndef QHULLFACET_H
 #define QHULLFACET_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 #include "libqhullcpp/QhullHyperplane.h"
 #include "libqhullcpp/QhullPoint.h"
 #include "libqhullcpp/QhullSet.h"

--- a/src/libqhullcpp/QhullHyperplane.h
+++ b/src/libqhullcpp/QhullHyperplane.h
@@ -9,9 +9,7 @@
 #ifndef QHHYPERPLANE_H
 #define QHHYPERPLANE_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 #include "libqhullcpp/QhullError.h"
 #include "libqhullcpp/QhullIterator.h"
 #include "libqhullcpp/QhullQh.h"

--- a/src/libqhullcpp/QhullIterator.h
+++ b/src/libqhullcpp/QhullIterator.h
@@ -9,9 +9,7 @@
 #ifndef QHULLITERATOR_H
 #define QHULLITERATOR_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 
 #include <assert.h>
 #include <iterator>

--- a/src/libqhullcpp/QhullLinkedList.h
+++ b/src/libqhullcpp/QhullLinkedList.h
@@ -9,9 +9,7 @@
 #ifndef QHULLLINKEDLIST_H
 #define QHULLLINKEDLIST_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 #include "libqhullcpp/QhullError.h"
 
 #include <cstddef>  // ptrdiff_t, size_t

--- a/src/libqhullcpp/QhullPoint.h
+++ b/src/libqhullcpp/QhullPoint.h
@@ -9,9 +9,7 @@
 #ifndef QHPOINT_H
 #define QHPOINT_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 #include "libqhullcpp/QhullError.h"
 #include "libqhullcpp/QhullIterator.h"
 #include "libqhullcpp/QhullQh.h"

--- a/src/libqhullcpp/QhullPointSet.h
+++ b/src/libqhullcpp/QhullPointSet.h
@@ -9,9 +9,7 @@
 #ifndef QHULLPOINTSET_H
 #define QHULLPOINTSET_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 #include "libqhullcpp/QhullSet.h"
 #include "libqhullcpp/QhullPoint.h"
 

--- a/src/libqhullcpp/QhullPoints.h
+++ b/src/libqhullcpp/QhullPoints.h
@@ -9,9 +9,7 @@
 #ifndef QHULLPOINTS_H
 #define QHULLPOINTS_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 #include "libqhullcpp/QhullPoint.h"
 
 #include <cstddef>  // ptrdiff_t, size_t

--- a/src/libqhullcpp/QhullQh.h
+++ b/src/libqhullcpp/QhullQh.h
@@ -9,9 +9,7 @@
 #ifndef QHULLQH_H
 #define QHULLQH_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 
 #include <string>
 

--- a/src/libqhullcpp/QhullRidge.h
+++ b/src/libqhullcpp/QhullRidge.h
@@ -9,9 +9,7 @@
 #ifndef QHULLRIDGE_H
 #define QHULLRIDGE_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 #include "libqhullcpp/QhullSet.h"
 #include "libqhullcpp/QhullVertex.h"
 #include "libqhullcpp/QhullVertexSet.h"

--- a/src/libqhullcpp/QhullSet.h
+++ b/src/libqhullcpp/QhullSet.h
@@ -9,9 +9,7 @@
 #ifndef QhullSet_H
 #define QhullSet_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 #include "libqhullcpp/QhullError.h"
 #include "libqhullcpp/QhullQh.h"
 

--- a/src/libqhullcpp/QhullStat.h
+++ b/src/libqhullcpp/QhullStat.h
@@ -9,9 +9,7 @@
 #ifndef QHULLSTAT_H
 #define QHULLSTAT_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 
 #include <string>
 #include <vector>

--- a/src/libqhullcpp/QhullVertex.h
+++ b/src/libqhullcpp/QhullVertex.h
@@ -9,9 +9,7 @@
 #ifndef QHULLVERTEX_H
 #define QHULLVERTEX_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 #include "libqhullcpp/QhullPoint.h"
 #include "libqhullcpp/QhullLinkedList.h"
 #include "libqhullcpp/QhullSet.h"

--- a/src/libqhullcpp/RboxPoints.h
+++ b/src/libqhullcpp/RboxPoints.h
@@ -9,9 +9,7 @@
 #ifndef RBOXPOINTS_H
 #define RBOXPOINTS_H
 
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 #include "libqhullcpp/QhullPoint.h"
 #include "libqhullcpp/PointCoordinates.h"
 

--- a/src/libqhullcpp/RoadError.h
+++ b/src/libqhullcpp/RoadError.h
@@ -9,9 +9,7 @@
 #ifndef ROADERROR_H
 #define ROADERROR_H
 
-extern "C" {
-    #include "libqhull_r/user_r.h"  /* for QHULL_CRTDBG */
-}
+#include "libqhull_r/user_r.h"  /* for QHULL_CRTDBG */
 #include "libqhullcpp/RoadLogEvent.h"
 
 #include <iostream>

--- a/src/qhulltest/qhulltest.cpp
+++ b/src/qhulltest/qhulltest.cpp
@@ -7,16 +7,13 @@
 ****************************************************************************/
 
 //pre-compiled headers
-extern "C" {
-    #include "libqhull_r/user_r.h"
-}
+#include "libqhull_r/user_r.h"
+
 #include <iostream>
 #include "RoadTest.h" // QT_VERSION
 
 #include "libqhullcpp/RoadError.h"
-extern "C" {
-    #include "libqhull_r/qhull_ra.h"
-}
+#include "libqhull_r/qhull_ra.h"
 
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
This commit moves the extern "C" { ... } logic into headers themselves. This way, it's the headers responsibility to define it's linkage appropriately and the consuming C and C++ code can both use "#include" without ifdef guards.