### PR TITLE
Get rid of -Wunused-but-set-variable when compiling with -Wall.

### DIFF
--- a/src/libqhull/mem.h
+++ b/src/libqhull/mem.h
@@ -159,11 +159,12 @@ struct qhmemT {               /* global memory management variables */
 
 #if defined qh_NOmem
 #define qh_memalloc_(insize, freelistp, object, type) {\
+  (void)freelistp; /* Avoid warnings */ \
   object= (type*)qh_memalloc(insize); }
 #elif defined qh_TRACEshort
 #define qh_memalloc_(insize, freelistp, object, type) {\
-    freelistp= NULL; /* Avoid warnings */ \
-    object= (type*)qh_memalloc(insize); }
+  (void)freelistp; /* Avoid warnings */ \
+  object= (type*)qh_memalloc(insize); }
 #else /* !qh_NOmem */
 
 #define qh_memalloc_(insize, freelistp, object, type) {\
@@ -188,11 +189,12 @@ struct qhmemT {               /* global memory management variables */
 */
 #if defined qh_NOmem
 #define qh_memfree_(object, insize, freelistp) {\
+  (void)freelistp; /* Avoid warnings */ \
   qh_memfree(object, insize); }
 #elif defined qh_TRACEshort
 #define qh_memfree_(object, insize, freelistp) {\
-    freelistp= NULL; /* Avoid warnings */ \
-    qh_memfree(object, insize); }
+  (void)freelistp; /* Avoid warnings */ \
+  qh_memfree(object, insize); }
 #else /* !qh_NOmem */
 
 #define qh_memfree_(object, insize, freelistp) {\

--- a/src/libqhull_r/mem_r.h
+++ b/src/libqhull_r/mem_r.h
@@ -163,11 +163,12 @@ struct qhmemT {               /* global memory management variables */
 
 #if defined qh_NOmem
 #define qh_memalloc_(qh, insize, freelistp, object, type) {\
+  (void)freelistp; /* Avoid warnings */ \
   object= (type*)qh_memalloc(qh, insize); }
 #elif defined qh_TRACEshort
 #define qh_memalloc_(qh, insize, freelistp, object, type) {\
-    freelistp= NULL; /* Avoid warnings */ \
-    object= (type*)qh_memalloc(qh, insize); }
+  (void)freelistp; /* Avoid warnings */ \
+  object= (type*)qh_memalloc(qh, insize); }
 #else /* !qh_NOmem */
 
 #define qh_memalloc_(qh, insize, freelistp, object, type) {\
@@ -192,11 +193,12 @@ struct qhmemT {               /* global memory management variables */
 */
 #if defined qh_NOmem
 #define qh_memfree_(qh, object, insize, freelistp) {\
+  (void)freelistp; /* Avoid warnings */ \
   qh_memfree(qh, object, insize); }
 #elif defined qh_TRACEshort
 #define qh_memfree_(qh, object, insize, freelistp) {\
-    freelistp= NULL; /* Avoid warnings */ \
-    qh_memfree(qh, object, insize); }
+  (void)freelistp; /* Avoid warnings */ \
+  qh_memfree(qh, object, insize); }
 #else /* !qh_NOmem */
 
 #define qh_memfree_(qh, object, insize, freelistp) {\


### PR DESCRIPTION
Casting to (void) is a standard way to state that a variable is unused.