### PR TITLE
Fix some apparently missing braces.

### DIFF
--- a/src/libqhull/io.c
+++ b/src/libqhull/io.c
@@ -2621,7 +2621,7 @@ void qh_printfacetridges(FILE *fp, facetT *facet) {
       qh_fprintf(fp, 9183, "     - all ridges:");
       FOREACHridge_(facet->ridges)
         qh_fprintf(fp, 9184, " r%d", ridge->id);
-        qh_fprintf(fp, 9185, "\n");
+      qh_fprintf(fp, 9185, "\n");
     }
     FOREACHridge_(facet->ridges) {
       if (!ridge->seen)

--- a/src/libqhull/random.c
+++ b/src/libqhull/random.c
@@ -81,9 +81,10 @@ int qh_argv_to_command(int argc, char *argv[], char* command, int max_size) {
       *t= '\0';
     }else if (remaining < 0) {
       goto error_argv;
-    }else
+    }else {
       strcat(command, " ");
       strcat(command, s);
+    }
   }
   return 1;
 

--- a/src/libqhull_r/io_r.c
+++ b/src/libqhull_r/io_r.c
@@ -2621,7 +2621,7 @@ void qh_printfacetridges(qhT *qh, FILE *fp, facetT *facet) {
       qh_fprintf(qh, fp, 9183, "     - all ridges:");
       FOREACHridge_(facet->ridges)
         qh_fprintf(qh, fp, 9184, " r%d", ridge->id);
-        qh_fprintf(qh, fp, 9185, "\n");
+      qh_fprintf(qh, fp, 9185, "\n");
     }
     FOREACHridge_(facet->ridges) {
       if (!ridge->seen)

--- a/src/libqhull_r/random_r.c
+++ b/src/libqhull_r/random_r.c
@@ -81,9 +81,10 @@ int qh_argv_to_command(int argc, char *argv[], char* command, int max_size) {
       *t= '\0';
     }else if (remaining < 0) {
       goto error_argv;
-    }else
+    }else {
       strcat(command, " ");
       strcat(command, s);
+    }
   }
   return 1;
 


### PR DESCRIPTION
Caught by gcc's -Wmisleading-indentation.

Note: Technically this changes the execution flow at that point; I
haven't checked whether this is desired but it looks like the previous
version was a incorrect...