### PR TITLE
Issue #37: Fix -Wstringop-truncation Warning

### DIFF
--- a/src/libqhull_r/rboxlib_r.c
+++ b/src/libqhull_r/rboxlib_r.c
@@ -87,7 +87,7 @@ int qh_rboxpoints(qhT *qh, char* rbox_command) {
   double anglediff, angle, x, y, cube= 0.0, diamond= 0.0;
   double box= qh_DEFAULTbox; /* scale all numbers before output */
   double randmax= qh_RANDOMmax;
-  char command[200], seedbuf[200];
+  char command[400], seedbuf[200];
   char *s= command, *t, *first_point= NULL;
   time_t timedata;
   int exitcode;
@@ -101,7 +101,7 @@ int qh_rboxpoints(qhT *qh, char* rbox_command) {
   }
 
   *command= '\0';
-  strncat(command, rbox_command, sizeof(command)-strlen(command)-1);
+  strncat(command, rbox_command, sizeof(command)-sizeof(seedbuf)-strlen(command)-1);
 
   while (*s && !isspace(*s))  /* skip program name */
     s++;


### PR DESCRIPTION
This fixes the warning, by ensuring there are at least 200 bytes free in `command` when `seedbuf` (size 200) is appended using `strncat`.