### PR TITLE
Build libqhullcpp with position independent code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,7 +466,8 @@ endif(UNIX)
 
 add_library(${qhull_CPP} STATIC ${libqhullcpp_SOURCES})
 set_target_properties(${qhull_CPP} PROPERTIES
-    VERSION ${qhull_VERSION})
+    VERSION ${qhull_VERSION}
+    POSITION_INDEPENDENT_CODE "TRUE")
 
 # ---------------------------------------
 # Define qhull executables linked to qhullstatic library


### PR DESCRIPTION
This allows `libqhullcpp.a` to be linked into shared libraries (i.e. python modules) on platforms that require position independent code. 

Motivation: Arch Linux [recently stopped adding](https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/qhull&id=8e9850ad8332d316c7f705e392e1db6ccd6dea2c) `-fPIC` to `CFLAGS` during the package build process. Making this change in the qhull source will ensure that future releases enable this use case on Arch Linux and all other packaging systems without requiring any special flags during the packaging process.