### PR TITLE
Change to CMAKE_CURRENT_SOURCE_DIR so it is easier to add_subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,7 +333,7 @@ set(
         index.htm
 )
 
-include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 if(CMAKE_BUILD_TYPE MATCHES "[dD]ebug")
     set(qhull_CPP qhullcpp_d)


### PR DESCRIPTION
This small changes allow qhull to be added as a subdirectory from other projects, but does not impact building it standalone.