### PR TITLE
Fix various typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,7 +483,7 @@ if(NOT ${BUILD_SHARED_LIBS})
 endif()
 
 # ---------------------------------------
-# Define options for linking to shared libaries
+# Define options for linking to shared libraries
 # ---------------------------------------
 if(MSVC) 
     set(qconvex_DEFINES  qh_dllimport)
@@ -623,7 +623,7 @@ if(${BUILD_STATIC_LIBS})
 endif()
 
 # ---------------------------------------
-# qhullp is qhull/unix.c linked to unsuported qh_QHpointer libqhull_p
+# qhullp is qhull/unix.c linked to unsupported qh_QHpointer libqhull_p
 # Included for testing qh_QHpointer 
 # ---------------------------------------
 
@@ -633,7 +633,7 @@ set_target_properties(qhullp PROPERTIES
     COMPILE_DEFINITIONS "${qhullp_DEFINES}")
 
 # ---------------------------------------
-# user_egp is user_eg/user_eg.c linked to unsuported qh_QHpointer libqhull_p
+# user_egp is user_eg/user_eg.c linked to unsupported qh_QHpointer libqhull_p
 # Included for compatibility with qhull-2012.1 
 # ---------------------------------------
 

--- a/eg/make-vcproj.sh
+++ b/eg/make-vcproj.sh
@@ -23,7 +23,7 @@ if [[ "$1" == "qhull-x" ]]; then
     set -v
     win64=1
     if [[ ! -w build/qhull.sln || ! -r build/qhull-64.vcxproj || ! -d src/libqhull_r ]]; then
-        echo "Excute 'eg/make-vcproj.sh qhull-x' from qhull directory with build/qhull.sln, build/qhull-64.vcxproj, src/libqhull_r"
+        echo "Execute 'eg/make-vcproj.sh qhull-x' from qhull directory with build/qhull.sln, build/qhull-64.vcxproj, src/libqhull_r"
         exit
     fi
 
@@ -128,7 +128,7 @@ if [[ "$1" == "sed-only" || "$2" == "sed-only" ]]; then
 else # else execute to 'fi ... sed-only'
 
 if [[ ! -f CMakeLists.txt || ! -f src/qhull-all.pro ]]; then
-    echo "Excute eg/make-vcproj.sh from qhull directory with CMakeLists.txt and src/qhull-all.pro"
+    echo "Execute eg/make-vcproj.sh from qhull directory with CMakeLists.txt and src/qhull-all.pro"
     exit
 fi
 

--- a/eg/qtest.sh
+++ b/eg/qtest.sh
@@ -126,7 +126,7 @@ if ! which rbox >/dev/null 2>&1; then
     fi
     PATH="$PWD/bin:$PATH"
     if ! which rbox >/dev/null 2>&1; then
-        echo 'eg/qtest.sh: Failed to temporily add "$PWD/bin" to $PATH for access to $QHULL and rbox'  "'$QHULL'." 'Please execute "export PATH=$PWD/bin:$PATH"'
+        echo 'eg/qtest.sh: Failed to temporarily add "$PWD/bin" to $PATH for access to $QHULL and rbox'  "'$QHULL'." 'Please execute "export PATH=$PWD/bin:$PATH"'
         exit 1
     fi
 fi

--- a/html/index.htm
+++ b/html/index.htm
@@ -445,7 +445,7 @@ the last point is <i>n-1</i>.</p>
 ('<a href="qh-optq.htm#Qbk">Qbk:n</a>', etc.), drop facets
 ('<a href="qh-optp.htm#Pdk">Pdk:n</a>', etc.), and
 Qhull command ('<a href="qh-optf.htm#FQ">FQ</a>'), only the last
-occurence of an option counts.
+occurrence of an option counts.
 Bounding box and drop facets may be repeated for each dimension.
 Option 'FQ' may be repeated any number of times.
 

--- a/html/qh-code.htm
+++ b/html/qh-code.htm
@@ -151,7 +151,7 @@ Simple C++ programs should compile as is.
 
 <p>Suggestions for updating src/libqhull/* from src/libqhull_r/*:
 <ul>
-<li>Make edits to libqhull_r/* instead of libqhull/*.  The reverse update is more difficult, as desribed above.
+<li>Make edits to libqhull_r/* instead of libqhull/*.  The reverse update is more difficult, as described above.
 <li>Use 'eg/make-qhull_qh.sh libqhull_r' to automatically convert libqhull_r/* to qhull_qh/*
 <li>Compare src/qhull_qh/ to src/libqhull/ using Beyond Compare (<a href="https://www.scootersoftware.com/">www.scootersoftware.com</a>)
 or another directory comparison utility.
@@ -446,7 +446,7 @@ Please add notes to <a href="http://github.com/qhull/qhull/wiki">Qhull Wiki</a>.
 <li>Infinite point as !defined()
 <li>qlist and qlinkedlist define pointer, reference, size_type, difference_type, const_pointer, const_reference for the class but not for iterator and const_iterator
       vector.h -- <pre>reference operator[](difference_type _Off) const</pre>
-<li>When forwarding an implementation is base() an approriate name (e.g., Coordinates::iterator::base() as std::vector<coordT>::iterator).
+<li>When forwarding an implementation is base() an appropriate name (e.g., Coordinates::iterator::base() as std::vector<coordT>::iterator).
 <li>When forwarding an implementation, does not work "returning address of temporary"
 <li>Also --, +=, and -=
        <pre>iterator       &operator++() { return iterator(i++); }</pre>
@@ -532,7 +532,7 @@ href="qh-optt.htm#Tz">Tz</a>'.</p>
 
 <p>Qhull does not use stderr, stdout, fprintf(), or exit() directly.</p>
 
-<p>Qhull reports errors via qh_errexit() by writting a message to qh.ferr and invoking longjmp().
+<p>Qhull reports errors via qh_errexit() by writing a message to qh.ferr and invoking longjmp().
 This returns the caller to the corresponding setjmp() (c.f., QH_TRY_ in QhullQh.h).  If
 qh_errexit() is not available, Qhull functions call qh_exit().   qh_exit() normally calls exit(),
 but may be redefined by the user.  An example is
@@ -922,7 +922,7 @@ an execution of Qhull at various levels of detail, with various options to contr
 <li>Level 2 ('T2') -- Minor steps in the program are prefixed with '[QH2nnn]'.
 <li>Level 3 ('T3') -- Merge and other events are prefixed with '[QH3nnn]'.
 <li>Level 4 ('T4') -- Detailed trace of Qhull execution.
-<li>Level 5 ('T5') -- Memory allocations and Guassian elimination.  Memory allocations are prefixed with "qh_mem " followed by address, sequence number, alloc/free, short/long, etc.
+<li>Level 5 ('T5') -- Memory allocations and Gaussian elimination.  Memory allocations are prefixed with "qh_mem " followed by address, sequence number, alloc/free, short/long, etc.
 If you sort by address and sequence number, each allocate should be paired with its free.
 </ul></p>
 
@@ -1282,7 +1282,7 @@ Top Suggestions
  - Constrain delaunay triangulations via Shewchuk's algorithm (ACM Symp. Comp. Geo., 1998)
 
 -----------
-To do for a furture version of the C++ interface
+To do for a future version of the C++ interface
  - Document C++ using Doxygen conventions (//! and //!<)
  - Add defineAs() to each object
  - Add Qtest::toString() functions for QhullPoint and others.  QByteArray and qstrdup()

--- a/html/qh-impre.htm
+++ b/html/qh-impre.htm
@@ -676,7 +676,7 @@ a topological error (<tt>eg/qtest.sh 10 '400 C1,2e-13 D5' 'Q14 d Qbb'</tt>).
 set (i.e., on the edge between the upper and lower convex hull).  After multiple facet merges, four
 facets may share a "dupridge" and must be merged.
 Some of these facets may be twisted relative to each other, leading to a very wide merged facet.
-If so, error QH6271 is reported.  It may be overriden with option '<a href="qh-optq.htm#Q12">Q12</a>'.
+If so, error QH6271 is reported.  It may be overridden with option '<a href="qh-optq.htm#Q12">Q12</a>'.
 
 <p>A "dupridge" may occur when the horizon facets for a new point is "pinched" (i.e., two vertices are
 nearly adjacent).

--- a/html/qh-optt.htm
+++ b/html/qh-optt.htm
@@ -83,7 +83,7 @@ indicated by 'T' followed by a letter.
     <dt><a href="#TPn">TPn</a></dt>
     <dd>turn on tracing when point n added to hull</dd>
     <dt><a href="#TRn">TRn</a></dt>
-    <dd>rerun qhull n times for QJn statitics</dd>
+    <dd>rerun qhull n times for QJn statistics</dd>
     <dt><a href="#TVn">TV-n</a></dt>
     <dd>stop qhull before adding point n</dd>
     <dt><a href="#TVn2">TVn</a></dt>
@@ -200,7 +200,7 @@ Use options 'TPn TWn' to
 trace the addition of point n to the convex hull, partitions
 of point n, and wide merges.</p>
 
-<h3><a href="#trace">&#187;</a><a name="TRn">TRn - rerun qhull n times for QJn statitics</a></h3>
+<h3><a href="#trace">&#187;</a><a name="TRn">TRn - rerun qhull n times for QJn statistics</a></h3>
 
 <p>Option 'TRn' reruns Qhull n times.  It is used
 with '<a href="qh-optq.htm#QJn">QJn</a>' to determine the probability

--- a/html/qhull-cpp.xml
+++ b/html/qhull-cpp.xml
@@ -197,7 +197,7 @@
             </li><li>
                 private functions -- No syntactic indication.  They may become public later on.
             </li><li>
-                Error messages -- Preceed error messages with the name of the class throwing the error (e.g. "ClassName: ...").  If this is an internal error, use "ClassName inconsistent: ..."
+                Error messages -- Precede error messages with the name of the class throwing the error (e.g. "ClassName: ...").  If this is an internal error, use "ClassName inconsistent: ..."
             </li><li>
                parameter order -- qhRunId, dimension, coordinates, count.
             </li><li>

--- a/src/Changes.txt
+++ b/src/Changes.txt
@@ -422,7 +422,7 @@ Qhull builds, scripts, and debugging
 - eg/q_test: update error messages for missing bin/ and bin/libqhull_r.dll
 - eg/q_test: tests of Tf and TAn
 - eg/qhull-zip.sh: add note that it requires road-script.sh from http://www.qhull.org/road/
-- eg/qhull-zip.sh: check source depencencies for prompts
+- eg/qhull-zip.sh: check source dependencies for prompts
 - eg/qtest.sh: new script for testing Qhull and summarizing its trace files
 - libqhull_r/Makefile: install target creates $INCDIR/libqhull_r and $LIBDIR
 - libqhull_r.h/qh_ERRdebug: define error status for debugging exits
@@ -692,8 +692,8 @@ Qhull options
    Renamed 'new' to 'newfacet'
    'isarea' if area is listed for the facet
    'cycledone' if qh_mergefacet completed  
-   Renamed 'MERGE' to 'MERGEridge' in the facet neighors (for merging)
-   Renamed 'DUP' to 'DUPLICATEridge' in the facet neighors (for merging)
+   Renamed 'MERGE' to 'MERGEridge' in the facet neighbors (for merging)
+   Renamed 'DUP' to 'DUPLICATEridge' in the facet neighbors (for merging)
    Comment '- horizon ridge to visible facet' added for tentative new facets
  - option 'f' (print facets): updated flags for ridges
    'mergevertex' and 'mergevertex2' if a ridge vertex will be merged
@@ -739,7 +739,7 @@ Bugs fixed
  - user_eg2.c: do not call qh_check_points if qh.FORCEoutput
  
 Qhull error reporting
- - io_r.c/qh_readpoints: improved formating of error "QH6410 ... instead of n points"
+ - io_r.c/qh_readpoints: improved formatting of error "QH6410 ... instead of n points"
  - libqulll_r.c/qh_findhorizon: error if no neighbors for a visible facet
  - libqulll_r.c/qh_findbestnew: error if facet sentinel (!facet->next)
  - libqhull_r.c/qh_nextfurthest: error if infinite loop
@@ -752,7 +752,7 @@ Qhull error reporting
              Call from qh_mergecycle, qh_makenewfacets, qh_attachnewfacets
  - merge_r.c/qh_maydropneighbor: error if simplicial facet or neighbor
  - merge_r.c/qh_merge_facet: error if wide merge (allow with 'Q12')
- - merge_r.c/qh_merge_nonconvex: error if unexected mergetype
+ - merge_r.c/qh_merge_nonconvex: error if unexpected mergetype
  - poly_r.c/qh_matchneighbor: convert error QH6106 (two facets with same vertices) to a warning (QH7084) and automatic fix
  - poly2_r.c/qh_check_maxout: error if wide qh.max_outside/min_vertex (allow with 'Q12')
  - poly2_r.c/qh_check_maxout: warn if wide maxout for vertices (for diagnosing errors)
@@ -1804,7 +1804,7 @@ Preliminary C++ support:
  - Preliminary documentation for Qhull's C++ interface [qh-code.htm#cpp, qhull-cpp.xml]
  - Added user_eg3 as an example of Qhull.cpp
  - Removed qhull_interface.cpp.  Use Qhull.cpp instead.
-   If math.h breaks '#include qhull_a.h', preceed it with '#include math.h'
+   If math.h breaks '#include qhull_a.h', precede it with '#include math.h'
 
 Changes to qhull options and results
  - Allow 'd' and 'v' as the filename for 'TO ..' and 'TI ...' in qdelaunay [M. Jambon]
@@ -2072,7 +2072,7 @@ Changes to options
  - If 'TPn' and 'TWn' defined, trace the addition of point 'n'
      otherwise continue tracing (previously it stopped in 4-d)
  - Removed 'Ft' from qdelaunay.  Use 'Qt o' or 'qhull d QJ Qt' instead.
-     For non-simplicial regions, 'Ft' does not satisify the Delaunay property.
+     For non-simplicial regions, 'Ft' does not satisfy the Delaunay property.
  - If 'Po' or 'TVn', qhull checks outer planes.  Use 'Q5' to turn off.
  - If 'T4', print facet lists and check polygon after adding each point
 
@@ -2944,7 +2944,7 @@ qhull V2.02 1/25/95
 
 ------------
 qhull V2.01 6/20/94
-  - fixed bug in qh_matchnewfacets that occured when memory alignment makes
+  - fixed bug in qh_matchnewfacets that occurred when memory alignment makes
     facet->neighbors larger than necessary.
   - fixed bug in computing worst-case simplicial merge of angle coplanar
     facets (ONEmerge).  This decreases (...x) in printsummary.
@@ -2965,7 +2965,7 @@ qhull V2.01 6/11/94
   - if pre-merge, 'Qf' is automatically set.  Otherwise an outside point may
         be dropt by qh_findbest().  This slows down partitioning.
   - always use 'Qc' if merging and all facet->maxoutside's must be right.
-        Otherwise distributions with many coplanar points may occassionally
+        Otherwise distributions with many coplanar points may occasionally
         miss a coplanar point for a facet.  This is because qh_findbest, when
         called by qh_check_maxout, can become stuck at a local maximum if
         the search is started at an arbitrary facet.  With 'Qc', the search

--- a/src/libqhull/geom2.c
+++ b/src/libqhull/geom2.c
@@ -2196,7 +2196,7 @@ coordT qh_vertex_bestdist2(setT *vertices, vertexT **vertexp/*= NULL*/, vertexT 
 
   qh_voronoi_center( dim, points )
     return Voronoi center for a set of points
-    dim is the orginal dimension of the points
+    dim is the original dimension of the points
     gh.gm_matrix/qh.gm_row are scratch buffers
 
   returns:

--- a/src/libqhull/poly2.c
+++ b/src/libqhull/poly2.c
@@ -2090,7 +2090,7 @@ void qh_infiniteloop(facetT *facet) {
 
   returns:
     qh_facetlist with initial hull
-    points partioned into outside sets, coplanar sets, or inside
+    points partitioned into outside sets, coplanar sets, or inside
     initializes qh.GOODpointp, qh.GOODvertexp,
 
   design:

--- a/src/libqhull/qh-stat.htm
+++ b/src/libqhull/qh-stat.htm
@@ -76,7 +76,7 @@ constants</a></h3>
 remain defined if qh_KEEPstatistics=0
 </li>
 <li><a href="stat.h#ztype">ztype</a> zdoc, zinc, etc.
-for definining statistics </li>
+for defining statistics </li>
 </ul>
 <h3><a href="qh-stat.htm#TOC">&#187;</a><a name="tmacro">stat.h macros</a></h3>
 <ul>

--- a/src/libqhull/user.h
+++ b/src/libqhull/user.h
@@ -104,7 +104,7 @@ Code flags --
     set the size of floating point numbers
 
   qh_REALdigits
-    maximimum number of significant digits
+    maximum number of significant digits
 
   qh_REAL_1, qh_REAL_2n, qh_REAL_3n
     format strings for printf

--- a/src/libqhull_r/geom2_r.c
+++ b/src/libqhull_r/geom2_r.c
@@ -2197,7 +2197,7 @@ coordT qh_vertex_bestdist2(qhT *qh, setT *vertices, vertexT **vertexp/*= NULL*/,
 
   qh_voronoi_center(qh, dim, points )
     return Voronoi center for a set of points
-    dim is the orginal dimension of the points
+    dim is the original dimension of the points
     gh.gm_matrix/qh.gm_row are scratch buffers
 
   returns:

--- a/src/libqhull_r/poly2_r.c
+++ b/src/libqhull_r/poly2_r.c
@@ -2091,7 +2091,7 @@ void qh_infiniteloop(qhT *qh, facetT *facet) {
 
   returns:
     qh_facetlist with initial hull
-    points partioned into outside sets, coplanar sets, or inside
+    points partitioned into outside sets, coplanar sets, or inside
     initializes qh.GOODpointp, qh.GOODvertexp,
 
   design:

--- a/src/libqhull_r/qh-stat_r.htm
+++ b/src/libqhull_r/qh-stat_r.htm
@@ -76,7 +76,7 @@ constants</a></h3>
 remain defined if qh_KEEPstatistics=0
 </li>
 <li><a href="stat_r.h#ztype">ztype</a> zdoc, zinc, etc.
-for definining statistics </li>
+for defining statistics </li>
 </ul>
 <h3><a href="qh-stat_r.htm#TOC">&#187;</a><a name="tmacro">stat_r.h macros</a></h3>
 <ul>

--- a/src/libqhull_r/user_r.h
+++ b/src/libqhull_r/user_r.h
@@ -103,7 +103,7 @@ Code flags --
     set the size of floating point numbers
 
   qh_REALdigits
-    maximimum number of significant digits
+    maximum number of significant digits
 
   qh_REAL_1, qh_REAL_2n, qh_REAL_3n
     format strings for printf

--- a/src/libqhullcpp/QhullSet.h
+++ b/src/libqhullcpp/QhullSet.h
@@ -278,7 +278,7 @@ public:
 
 //! QhullSetIterator is a Java-style iterator.  It may be used on temporary results.
 //! QhullSetIterator copies the qh_set and qh_qh pointers in QhullSetBase
-//! Faster then interator/const_iterator due to T::base_type
+//! Faster then iterator/const_iterator due to T::base_type
 template <typename T>
 class QhullSetIterator {
 

--- a/src/libqhullcpp/QhullVertexSet.cpp
+++ b/src/libqhullcpp/QhullVertexSet.cpp
@@ -40,7 +40,7 @@ QhullVertexSet(const Qhull &q, facetT *facetlist, setT *facetset, bool allfacets
     q.qh()->maybeThrowQhullMessage(QH_TRY_status);
 }//QhullVertexSet facetlist facetset
 
-//! Return tempory QhullVertexSet of vertices for a list and/or a set of facets
+//! Return temporary QhullVertexSet of vertices for a list and/or a set of facets
 //! Sets qhsettemp_defined (disallows copy constructor and assignment to prevent double-free)
 QhullVertexSet::
 QhullVertexSet(QhullQh *qqh, facetT *facetlist, setT *facetset, bool allfacets)

--- a/src/libqhullcpp/RoadError.h
+++ b/src/libqhullcpp/RoadError.h
@@ -33,7 +33,7 @@ private:
 #//!\name Fields
     int                 error_code;  //! Non-zero code (not logged), maybe returned as program status
     RoadLogEvent        log_event;   //! Format string w/ arguments
-    mutable std::string error_message;  //! Formated error message.  Must be after log_event.
+    mutable std::string error_message;  //! Formatted error message.  Must be after log_event.
 
 #//!\name Class fields
     static const char  *  ROADtag;

--- a/src/qhull-all.pro
+++ b/src/qhull-all.pro
@@ -9,7 +9,7 @@
 # qmake is in Qt's bin directory
 # mkdir -p build && cd build && qmake -tp vc -r ../src/qhull-all.pro
 # Additional Library Directories -- C:\qt\Qt5.2.0\5.2.0\msvc2012_64\lib
-# libqhullcpp and libqhullstatic refered to $(QTDIR) but apparently didn't retrieve (should be %QTDIR%?)
+# libqhullcpp and libqhullstatic referred to $(QTDIR) but apparently didn't retrieve (should be %QTDIR%?)
 # libqhull_r also needs ..\..\lib
 # Need to change build/x64/Debug/*.lib to lib/ (or copy libs by hand, each time)
 # Additional Build Dependencies

--- a/src/user_eg2/user_eg2.c
+++ b/src/user_eg2/user_eg2.c
@@ -291,7 +291,7 @@ notes:
   It is transformed by qh_sethalfspace_all into a
   (dim)-d set of newpoints.  Qhull computed the convex hull of newpoints -
   this is equivalent to the halfspace intersection of the
-  orginal halfspaces.
+  original halfspaces.
 
   For addhalf(), the remainder of points stores the transforms of
   the added halfspaces.  Qhull computes the convex hull of newpoints

--- a/src/user_eg2/user_eg2_r.c
+++ b/src/user_eg2/user_eg2_r.c
@@ -290,7 +290,7 @@ notes:
   It is transformed by qh_sethalfspace_all into a
   (dim)-d set of newpoints.  Qhull computed the convex hull of newpoints -
   this is equivalent to the halfspace intersection of the
-  orginal halfspaces.
+  original halfspaces.
 
   For addhalf(), the remainder of points stores the transforms of
   the added halfspaces.  Qhull computes the convex hull of newpoints


### PR DESCRIPTION
Found via `codespell -q 3 -L defineas,fo,merget`