### PR TITLE
Incorrect max coordinate in error messages

### DIFF
--- a/src/libqhull/user.c
+++ b/src/libqhull/user.c
@@ -539,7 +539,7 @@ the points by randomly rotating the input with 'QR0'.\n");
   qh_fprintf(fp, 9385, "\nThe min and max coordinates for each dimension are:\n");
   for (k=0; k < qh hull_dim; k++) {
     min= REALmax;
-    max= -REALmin;
+    max= -REALmax;
     for (i=qh num_points, coord= qh first_point+k; i--; coord += qh hull_dim) {
       maximize_(max, *coord);
       minimize_(min, *coord);

--- a/src/libqhull_r/user_r.c
+++ b/src/libqhull_r/user_r.c
@@ -526,7 +526,7 @@ the points by randomly rotating the input with 'QR0'.\n");
   qh_fprintf(qh, fp, 9385, "\nThe min and max coordinates for each dimension are:\n");
   for (k=0; k < qh->hull_dim; k++) {
     min= REALmax;
-    max= -REALmin;
+    max= -REALmax;
     for (i=qh->num_points, coord= qh->first_point+k; i--; coord += qh->hull_dim) {
       maximize_(max, *coord);
       minimize_(min, *coord);

--- a/src/user_eg2/user_eg2.c
+++ b/src/user_eg2/user_eg2.c
@@ -733,7 +733,7 @@ the points by randomly rotating the input with 'QR0'.\n");
   qh_fprintf(fp, 9385, "\nThe min and max coordinates for each dimension are:\n");
   for (k=0; k < qh hull_dim; k++) {
     min= REALmax;
-    max= -REALmin;
+    max= -REALmax;
     for (i=qh num_points, coord= qh first_point+k; i--; coord += qh hull_dim) {
       maximize_(max, *coord);
       minimize_(min, *coord);

--- a/src/user_eg2/user_eg2_r.c
+++ b/src/user_eg2/user_eg2_r.c
@@ -724,7 +724,7 @@ the points by randomly rotating the input with 'QR0'.\n");
   qh_fprintf(qh, fp, 9385, "\nThe min and max coordinates for each dimension are:\n");
   for (k=0; k < qh->hull_dim; k++) {
     min= REALmax;
-    max= -REALmin;
+    max= -REALmax;
     for (i=qh->num_points, coord= qh->first_point+k; i--; coord += qh->hull_dim) {
       maximize_(max, *coord);
       minimize_(min, *coord);


### PR DESCRIPTION
This is a really minor thing that only affects the error message, not the operation. It did confuse me for quite a while, so I thought I should probably go ahead and create a PR.

In the error message for singular input, the min/max values of input coordinates are listed. When all values of an axis are negative, the max value is given (in my case) as `-2.225e-308`, aka -DBL_MIN. Correspondingly, the reported difference max-min is also wrong.
This is because the min/max loop is initialized to the wrong value, -REALmin (which is near zero) instead of -REALmax (which is large negative).

The same code exists in multiple places, I adjusted all of them.

