### PR TITLE
Fix MSVC C4706 6 times in each qset.h

### DIFF
--- a/src/libqhull/qset.h
+++ b/src/libqhull/qset.h
@@ -136,9 +136,9 @@ struct setT {
      this includes intervening blocks, e.g. FOREACH...{ if () FOREACH...} )
 */
 #define FOREACHsetelement_(type, set, variable) \
-        if (((variable= NULL), set)) for (\
+        if (((variable= NULL) != 0, set)) for (\
           variable##p= (type **)&((set)->e[0].p); \
-          (variable= *variable##p++);)
+          (variable= *variable##p++) != 0;)
 
 /*-<a                                      href="qh-set.htm#TOC"
   >----------------------------------------</a><a name="FOREACHsetelement_i_">-</a>
@@ -169,7 +169,7 @@ struct setT {
      this includes intervening blocks, e.g. FOREACH...{ if () FOREACH...} )
 */
 #define FOREACHsetelement_i_(type, set, variable) \
-        if (((variable= NULL), set)) for (\
+        if (((variable= NULL) != 0, set)) for (\
           variable##_i= 0, variable= (type *)((set)->e[0].p), \
                    variable##_n= qh_setsize(set);\
           variable##_i < variable##_n;\
@@ -202,7 +202,7 @@ struct setT {
      WARNING: needs braces if nested inside another FOREACH
 */
 #define FOREACHsetelementreverse_(type, set, variable) \
-        if (((variable= NULL), set)) for (\
+        if (((variable= NULL) != 0, set)) for (\
            variable##temp= qh_setsize(set)-1, variable= qh_setlast(set);\
            variable; variable= \
            ((--variable##temp >= 0) ? SETelemt_(set, variable##temp, type) : NULL))
@@ -233,9 +233,9 @@ struct setT {
      WARNING: needs braces if nested inside another FOREACH
 */
 #define FOREACHsetelementreverse12_(type, set, variable) \
-        if (((variable= NULL), set)) for (\
+        if (((variable= NULL) != 0, set)) for (\
           variable##p= (type **)&((set)->e[1].p); \
-          (variable= *variable##p); \
+          (variable= *variable##p) != 0; \
           variable##p == ((type **)&((set)->e[0].p))?variable##p += 2: \
               (variable##p == ((type **)&((set)->e[1].p))?variable##p--:variable##p++))
 

--- a/src/libqhull_r/qset_r.h
+++ b/src/libqhull_r/qset_r.h
@@ -141,9 +141,9 @@ struct setT {
      this includes intervening blocks, e.g. FOREACH...{ if () FOREACH...} )
 */
 #define FOREACHsetelement_(type, set, variable) \
-        if (((variable= NULL), set)) for (\
+        if (((variable= NULL) != 0, set)) for (\
           variable##p= (type **)&((set)->e[0].p); \
-          (variable= *variable##p++);)
+          (variable= *variable##p++) != 0;)
 
 /*-<a                                      href="qh-set_r.htm#TOC"
   >----------------------------------------</a><a name="FOREACHsetelement_i_">-</a>
@@ -174,7 +174,7 @@ struct setT {
      this includes intervening blocks, e.g. FOREACH...{ if () FOREACH...} )
 */
 #define FOREACHsetelement_i_(qh, type, set, variable) \
-        if (((variable= NULL), set)) for (\
+        if (((variable= NULL) != 0, set)) for (\
           variable##_i= 0, variable= (type *)((set)->e[0].p), \
                    variable##_n= qh_setsize(qh, set);\
           variable##_i < variable##_n;\
@@ -207,7 +207,7 @@ struct setT {
      WARNING: needs braces if nested inside another FOREACH
 */
 #define FOREACHsetelementreverse_(qh, type, set, variable) \
-        if (((variable= NULL), set)) for (\
+        if (((variable= NULL) != 0, set)) for (\
            variable##temp= qh_setsize(qh, set)-1, variable= qh_setlast(qh, set);\
            variable; variable= \
            ((--variable##temp >= 0) ? SETelemt_(set, variable##temp, type) : NULL))
@@ -238,9 +238,9 @@ struct setT {
      WARNING: needs braces if nested inside another FOREACH
 */
 #define FOREACHsetelementreverse12_(type, set, variable) \
-        if (((variable= NULL), set)) for (\
+        if (((variable= NULL) != 0, set)) for (\
           variable##p= (type **)&((set)->e[1].p); \
-          (variable= *variable##p); \
+          (variable= *variable##p) != 0; \
           variable##p == ((type **)&((set)->e[0].p))?variable##p += 2: \
               (variable##p == ((type **)&((set)->e[1].p))?variable##p--:variable##p++))
 


### PR DESCRIPTION
I'm using Qhull in Unreal Engine and get [C4706](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4706) in concave_hull.hpp. This means, a variable assignment is used afterwards as a boolean.

![C4706](https://user-images.githubusercontent.com/2863821/125831772-357ca7bf-3f81-41f1-9524-67979f9b4e8d.png)

The reason is, the macro `FOREACHridge_` from libqhull.h uses `FOREACHsetelement_` from qset.h, where the variable is initialized with NULL and used as boolean and as 2nd for parameter the variable gets assigned the next iterator value and is used as boolean afterwards.

The suggested fix by Microsoft is to use `(var = value) != 0`, what I did 6x for qset.h and 6x for qset_r.h.
