### PR TITLE
add accessors_r.c to CMakeLists.txt for libqhull_r

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ set(
         src/libqhull_r/userprintf_r.c
         src/libqhull_r/io_r.c
         src/libqhull_r/user_r.c
+        src/libqhull_r/accessors_r.c
         src/libqhull_r/rboxlib_r.c
         src/libqhull_r/userprintf_rbox_r.c
         ${libqhullr_HEADERS}


### PR DESCRIPTION
#89 updated the `Makefile`, but I missed the fact that you also have a `CMakeLists.txt`.

cc @blegat