### PR TITLE
more accessor functions

### DIFF
--- a/src/libqhull_r/accessors_r.c
+++ b/src/libqhull_r/accessors_r.c
@@ -15,54 +15,55 @@ void qh_free_qh(qhT *qh) {
   qh_free(qh);
 }
 
-facetT *qh_get_facet_list(const qhT *qh) {
-  return qh->facet_list;
-}
+#define GETTER(TYPE, FIELD) TYPE qh_get_##FIELD(const qhT *qh) { return qh->FIELD; }
+#define SETTER(TYPE, FIELD) void qh_set_##FIELD(qhT *qh, TYPE _val_) { qh->FIELD = _val_; }
 
-pointT *qh_get_first_point(const qhT *qh) {
-  return qh->first_point;
-}
+/* required to emulate the various FOR* macros */
+GETTER(facetT*, facet_list)
+GETTER(pointT*, first_point)
+GETTER(int, hull_dim)
+GETTER(int, num_facets)
+GETTER(int, num_points)
+GETTER(int, num_vertices)
+GETTER(vertexT*, vertex_list)
 
-boolT qh_get_hasAreaVolume(const qhT *qh) {
-  return qh->hasAreaVolume;
-}
+/* suggested by @blegat based on Qhull.jl wrappers */
+GETTER(realT, totarea)
+GETTER(realT, totvol)
+GETTER(boolT, hasAreaVolume)
+SETTER(boolT, hasAreaVolume)
+GETTER(boolT, hasTriangulation)
+SETTER(boolT, hasTriangulation)
 
-boolT qh_get_hasTriangulation(const qhT *qh) {
-  return qh->hasTriangulation;
-}
+/* suggested by @JuhaHeiskala based on his DirectQHull.jl wrapper */
+GETTER(int, num_good)
+GETTER(setT*, del_vertices)
+GETTER(int, input_dim)
 
-int qh_get_hull_dim(const qhT *qh) {
-  return qh->hull_dim;
-}
-
-int qh_get_num_facets(const qhT *qh) {
-  return qh->num_facets;
-}
-
-int qh_get_num_points(const qhT *qh) {
-  return qh->num_points;
-}
-
-int qh_get_num_vertices(const qhT *qh) {
-  return qh->num_vertices;
-}
-
-realT qh_get_totarea(const qhT *qh) {
-  return qh->totarea;
-}
-
-realT qh_get_totvol(const qhT *qh) {
-  return qh->totvol;
-}
-
-vertexT *qh_get_vertex_list(const qhT *qh) {
-  return qh->vertex_list;
-}
-
-void qh_set_hasAreaVolume(qhT *qh, boolT val) {
-  qh->hasAreaVolume = val;
-}
-
-void qh_set_hasTriangulation(qhT *qh, boolT val) {
-  qh->hasTriangulation = val;
-}
+/* other accessors, mimicking those provided by the scipy API: */
+GETTER(boolT, DELAUNAY)
+GETTER(boolT, SCALElast)
+GETTER(boolT, KEEPcoplanar)
+GETTER(boolT, MERGEexact)
+GETTER(boolT, NOerrexit)
+GETTER(boolT, PROJECTdelaunay)
+GETTER(boolT, ATinfinity)
+GETTER(boolT, UPPERdelaunay)
+GETTER(int, normal_size)
+GETTER(int, num_visible)
+GETTER(int, center_size)
+GETTER(const char *, qhull_command)
+GETTER(facetT*, facet_tail)
+GETTER(vertexT*, vertex_tail)
+GETTER(unsigned int, facet_id)
+GETTER(unsigned int, visit_id)
+GETTER(unsigned int, vertex_visit)
+GETTER(pointT*, input_points)
+GETTER(coordT*, feasible_point)
+GETTER(realT, last_low)
+GETTER(realT, last_high)
+GETTER(realT, last_newhigh)
+GETTER(realT, max_outside)
+GETTER(realT, MINoutside)
+GETTER(realT, DISTround)
+GETTER(setT*, other_points)

--- a/src/libqhull_r/libqhull_r.h
+++ b/src/libqhull_r/libqhull_r.h
@@ -1219,21 +1219,51 @@ void    qh_collectstatistics(qhT *qh);
 void    qh_printallstatistics(qhT *qh, FILE *fp, const char *string);
 
 /************************** accessors.c prototypes ******************************/
-qhT     *qh_alloc_qh(FILE *errfile);
-void     qh_free_qh(qhT *qh);
-facetT  *qh_get_facet_list(const qhT *qh);
-pointT  *qh_get_first_point(const qhT *qh);
-boolT    qh_get_hasAreaVolume(const qhT *qh);
-boolT    qh_get_hasTriangulation(const qhT *qh);
-int      qh_get_hull_dim(const qhT *qh);
-int      qh_get_num_facets(const qhT *qh);
-int      qh_get_num_points(const qhT *qh);
-int      qh_get_num_vertices(const qhT *qh);
-realT    qh_get_totarea(const qhT *qh);
-realT    qh_get_totvol(const qhT *qh);
-vertexT *qh_get_vertex_list(const qhT *qh);
-void     qh_set_hasAreaVolume(qhT *qh, boolT val);
-void     qh_set_hasTriangulation(qhT *qh, boolT val);
+
+#define QH_GETTER(TYPE, FIELD) TYPE qh_get_##FIELD(const qhT *qh)
+#define QH_SETTER(TYPE, FIELD) void qh_set_##FIELD(qhT *qh, TYPE _val_)
+QH_GETTER(facetT*, facet_list);
+QH_GETTER(pointT*, first_point);
+QH_GETTER(int, hull_dim);
+QH_GETTER(int, num_facets);
+QH_GETTER(int, num_points);
+QH_GETTER(int, num_vertices);
+QH_GETTER(vertexT*, vertex_list);
+QH_GETTER(realT, totarea);
+QH_GETTER(realT, totvol);
+QH_GETTER(boolT, hasAreaVolume);
+QH_SETTER(boolT, hasAreaVolume);
+QH_GETTER(boolT, hasTriangulation);
+QH_SETTER(boolT, hasTriangulation);
+QH_GETTER(int, num_good);
+QH_GETTER(setT*, del_vertices);
+QH_GETTER(int, input_dim);
+QH_GETTER(boolT, DELAUNAY);
+QH_GETTER(boolT, SCALElast);
+QH_GETTER(boolT, KEEPcoplanar);
+QH_GETTER(boolT, MERGEexact);
+QH_GETTER(boolT, NOerrexit);
+QH_GETTER(boolT, PROJECTdelaunay);
+QH_GETTER(boolT, ATinfinity);
+QH_GETTER(boolT, UPPERdelaunay);
+QH_GETTER(int, normal_size);
+QH_GETTER(int, num_visible);
+QH_GETTER(int, center_size);
+QH_GETTER(const char *, qhull_command);
+QH_GETTER(facetT*, facet_tail);
+QH_GETTER(vertexT*, vertex_tail);
+QH_GETTER(unsigned int, facet_id);
+QH_GETTER(unsigned int, visit_id);
+QH_GETTER(unsigned int, vertex_visit);
+QH_GETTER(pointT*, input_points);
+QH_GETTER(coordT*, feasible_point);
+QH_GETTER(realT, last_low);
+QH_GETTER(realT, last_high);
+QH_GETTER(realT, last_newhigh);
+QH_GETTER(realT, max_outside);
+QH_GETTER(realT, MINoutside);
+QH_GETTER(realT, DISTround);
+QH_GETTER(setT*, other_points);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
Follows up on #89 by adding additional accessors suggested by @JuhaHeiskala in https://github.com/JuliaPolyhedra/QHull.jl/issues/19#issuecomment-944457116 — in particular, he points out that it would be good to expose at least as many fields as are provided by the [scipy API](https://github.com/scipy/scipy/blob/4aebbd953fec41b2f3ff3ebbeb2bf91e88d0da2d/scipy/spatial/qhull.pyx#L104-L142).

Also, since these accessor functions involve a lot of repeated code, I condensed the code by defining `GETTER` and `SETTER` macros.

cc @blegat