### PR TITLE
Adding the -lm for the shared library. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -744,7 +744,7 @@ lib/libqhullcpp.a: $(LIBQHULLCPP_OBJS)
 	#ranlib $@
 
 lib/libqhull_r.$(SO): $(LIBQHULLSR_RBOX_OBJS)
-	$(CC) -shared -o $@ $(CC_OPTS3) $^
+	$(CC) -shared -lm -o $@ $(CC_OPTS3) $^
 	# the following line fails under MSYS, not needed for SO=dll
 	-(cd lib/ && ln -f -s libqhull_r.$(SO) libqhull_r.so)
 	-(cd lib/ && ln -f -s libqhull_r.$(SO) libqhull_r.$(SONAME_EXT))


### PR DESCRIPTION
I would failed on AIX/IBM i without the "-lm" . I am not sure how it would work on other platforms, but I found -lm is available for most of other binaries. I think adding it would not do harm to other platforms. Please help to review and kindly merge it. thanks.