### PR TITLE
Use ${LIB_INSTALL_DIR} for cmake and pkgconfig files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,7 +701,7 @@ configure_file(${PROJECT_SOURCE_DIR}/build/config.cmake.in
   @ONLY
 )
 
-set(ConfigPackageLocation lib/cmake/Qhull)
+set(ConfigPackageLocation ${LIB_INSTALL_DIR}/cmake/Qhull)
 install(EXPORT QhullTargets
   FILE
     QhullTargets.cmake
@@ -720,7 +720,7 @@ install(
     Devel
 )
 
-set(PkgConfigLocation lib/pkgconfig)
+set(PkgConfigLocation ${LIB_INSTALL_DIR}/pkgconfig)
 foreach(pkgconfig IN ITEMS "${qhull_SHAREDR};Qhull reentrant shared library"
                            "${qhull_STATIC};Qhull static library"
                            "${qhull_STATICR};Qhull reentrant static library"


### PR DESCRIPTION
 to support multilib on Fedora/RedHat.