### PR TITLE
Add an option to skip building executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ cmake_dependent_option(LINK_APPS_SHARED "Use shared library for linking applicat
     ${BUILD_SHARED_LIBS}
 )
 option(QHULL_ENABLE_TESTING "Build and run tests" ON)
+option(BUILD_APPLICATIONS "Build applications" ON)
 
 if(INCLUDE_INSTALL_DIR)
 else()
@@ -521,129 +522,131 @@ endif()
 # If LINK_APPS_SHARED, applications are linked to reentrant qhull
 # ---------------------------------------
 
-if(${LINK_APPS_SHARED})
-    add_executable(qconvex src/qconvex/qconvex_r.c)
-    target_link_libraries(qconvex ${qhull_SHAREDR})
-    set_target_properties(qconvex PROPERTIES
-        COMPILE_DEFINITIONS "${qconvex_DEFINES}")
+if(BUILD_APPLICATIONS)
+    if(${LINK_APPS_SHARED})
+        add_executable(qconvex src/qconvex/qconvex_r.c)
+        target_link_libraries(qconvex ${qhull_SHAREDR})
+        set_target_properties(qconvex PROPERTIES
+            COMPILE_DEFINITIONS "${qconvex_DEFINES}")
 
-    add_executable(qdelaunay src/qdelaunay/qdelaun_r.c)
-    target_link_libraries(qdelaunay ${qhull_SHAREDR})
-    set_target_properties(qdelaunay PROPERTIES
-        COMPILE_DEFINITIONS "${qdelaunay_DEFINES}")
+        add_executable(qdelaunay src/qdelaunay/qdelaun_r.c)
+        target_link_libraries(qdelaunay ${qhull_SHAREDR})
+        set_target_properties(qdelaunay PROPERTIES
+            COMPILE_DEFINITIONS "${qdelaunay_DEFINES}")
 
-    add_executable(qhalf src/qhalf/qhalf_r.c)
-    target_link_libraries(qhalf ${qhull_SHAREDR})
-    set_target_properties(qhalf PROPERTIES
-        COMPILE_DEFINITIONS "${qhalf_DEFINES}")
+        add_executable(qhalf src/qhalf/qhalf_r.c)
+        target_link_libraries(qhalf ${qhull_SHAREDR})
+        set_target_properties(qhalf PROPERTIES
+            COMPILE_DEFINITIONS "${qhalf_DEFINES}")
 
-    add_executable(qhull src/qhull/unix_r.c)
-    target_link_libraries(qhull ${qhull_SHAREDR})
-    set_target_properties(qhull PROPERTIES
-        COMPILE_DEFINITIONS "${qhull_DEFINES}")
+        add_executable(qhull src/qhull/unix_r.c)
+        target_link_libraries(qhull ${qhull_SHAREDR})
+        set_target_properties(qhull PROPERTIES
+            COMPILE_DEFINITIONS "${qhull_DEFINES}")
 
-    add_executable(qvoronoi src/qvoronoi/qvoronoi_r.c)
-    target_link_libraries(qvoronoi ${qhull_SHAREDR})
-    set_target_properties(qvoronoi PROPERTIES
-        COMPILE_DEFINITIONS "${qvoronoi_DEFINES}")
+        add_executable(qvoronoi src/qvoronoi/qvoronoi_r.c)
+        target_link_libraries(qvoronoi ${qhull_SHAREDR})
+        set_target_properties(qvoronoi PROPERTIES
+            COMPILE_DEFINITIONS "${qvoronoi_DEFINES}")
 
-    add_executable(rbox src/rbox/rbox_r.c)
-    target_link_libraries(rbox ${qhull_SHAREDR})
-    set_target_properties(rbox PROPERTIES
-        COMPILE_DEFINITIONS "${rbox_DEFINES}")
-else()
-    if(NOT ${BUILD_STATIC_LIBS})
-        message(FATAL_ERROR, " Nothing to build -- BUILD_SHARED_LIBS=OFF and BUILD_STATIC_LIBS=OFF")
+        add_executable(rbox src/rbox/rbox_r.c)
+        target_link_libraries(rbox ${qhull_SHAREDR})
+        set_target_properties(rbox PROPERTIES
+            COMPILE_DEFINITIONS "${rbox_DEFINES}")
+    else()
+        if(NOT ${BUILD_STATIC_LIBS})
+            message(FATAL_ERROR, " Nothing to build -- BUILD_SHARED_LIBS=OFF and BUILD_STATIC_LIBS=OFF")
+        endif()
+
+        add_executable(qconvex src/qconvex/qconvex.c)
+        target_link_libraries(qconvex ${qhull_STATIC})
+
+        add_executable(qdelaunay src/qdelaunay/qdelaun.c)
+        target_link_libraries(qdelaunay ${qhull_STATIC})
+
+        add_executable(qhalf src/qhalf/qhalf.c)
+        target_link_libraries(qhalf ${qhull_STATIC})
+
+        add_executable(qhull src/qhull/unix_r.c)
+        target_link_libraries(qhull ${qhull_STATICR})
+
+        add_executable(qvoronoi src/qvoronoi/qvoronoi.c)
+        target_link_libraries(qvoronoi ${qhull_STATIC})
+
+        add_executable(rbox src/rbox/rbox.c)
+        target_link_libraries(rbox ${qhull_STATIC})
     endif()
 
-    add_executable(qconvex src/qconvex/qconvex.c)
-    target_link_libraries(qconvex ${qhull_STATIC})
+    # #@# 20
+    # ---------------------------------------
+    # Define testqset linked to qset.o, mem.o, and usermem.o
+    # Define testqset_r linked to qset_r.o, mem_r.o, and usermem.o
+    # ---------------------------------------
 
-    add_executable(qdelaunay src/qdelaunay/qdelaun.c)
-    target_link_libraries(qdelaunay ${qhull_STATIC})
+    add_executable(testqset ${testqset_SOURCES})
+    add_executable(testqset_r ${testqsetr_SOURCES})
 
-    add_executable(qhalf src/qhalf/qhalf.c)
-    target_link_libraries(qhalf ${qhull_STATIC})
+    # ---------------------------------------
+    # Define user_eg linked to reentrant qhull shared library
+    # ---------------------------------------
 
-    add_executable(qhull src/qhull/unix_r.c)
-    target_link_libraries(qhull ${qhull_STATICR})
+    add_executable(user_eg src/user_eg/user_eg_r.c)
 
-    add_executable(qvoronoi src/qvoronoi/qvoronoi.c)
-    target_link_libraries(qvoronoi ${qhull_STATIC})
+    if(${BUILD_SHARED_LIBS})
+        target_link_libraries(user_eg ${qhull_SHAREDR})
+        set_target_properties(user_eg PROPERTIES
+      COMPILE_DEFINITIONS "${user_eg_DEFINES}")
+    else()
+        target_link_libraries(user_eg ${qhull_STATICR})
+    endif()
 
-    add_executable(rbox src/rbox/rbox.c)
-    target_link_libraries(rbox ${qhull_STATIC})
+    # ---------------------------------------
+    # Define user_eg2 linked to reentrant qhull static library
+    # ---------------------------------------
+
+    add_executable(user_eg2 src/user_eg2/user_eg2_r.c)
+
+    if(${BUILD_STATIC_LIBS})
+        target_link_libraries(user_eg2 ${qhull_STATICR})
+    else()
+        target_link_libraries(user_eg2 ${qhull_SHAREDR})
+        set_target_properties(user_eg2 PROPERTIES
+      COMPILE_DEFINITIONS "${user_eg2_DEFINES}")
+    endif()
+
+    # ---------------------------------------
+    # Define user_eg3 linked to qhullcpp and qhullstatic_r static libraries
+    # 
+    # user_eg3 is not defined for shared libraries
+    #   user_eg3 and qhullcpp must be compiled with the same compiler for setjmp/longjmp
+    # ---------------------------------------
+
+    if(${BUILD_STATIC_LIBS})
+        add_executable(user_eg3 src/user_eg3/user_eg3_r.cpp)
+        # qhull_STATICR must be last, otherwise qh_fprintf,etc. are not loaded from qhull_CPP
+        target_link_libraries(user_eg3 ${qhull_CPP} ${qhull_STATICR})
+    endif()
+
+    # ---------------------------------------
+    # qhullp is qhull/unix.c linked to unsupported qh_QHpointer libqhull_p
+    # Included for testing qh_QHpointer 
+    # ---------------------------------------
+
+    add_executable(qhullp EXCLUDE_FROM_ALL src/qhull/unix.c)
+    target_link_libraries(qhullp ${qhull_SHAREDP})
+    set_target_properties(qhullp PROPERTIES
+        COMPILE_DEFINITIONS "${qhullp_DEFINES}")
+
+    # ---------------------------------------
+    # user_egp is user_eg/user_eg.c linked to unsupported qh_QHpointer libqhull_p
+    # Included for compatibility with qhull-2012.1 
+    # ---------------------------------------
+
+    add_executable(user_egp EXCLUDE_FROM_ALL src/user_eg/user_eg.c)
+    target_link_libraries(user_egp ${qhull_SHAREDP})
+    set_target_properties(user_egp PROPERTIES
+        COMPILE_DEFINITIONS "${user_egp_DEFINES}")
 endif()
-
-# #@# 20
-# ---------------------------------------
-# Define testqset linked to qset.o, mem.o, and usermem.o
-# Define testqset_r linked to qset_r.o, mem_r.o, and usermem.o
-# ---------------------------------------
-
-add_executable(testqset ${testqset_SOURCES})
-add_executable(testqset_r ${testqsetr_SOURCES})
-
-# ---------------------------------------
-# Define user_eg linked to reentrant qhull shared library
-# ---------------------------------------
-
-add_executable(user_eg src/user_eg/user_eg_r.c)
-
-if(${BUILD_SHARED_LIBS})
-    target_link_libraries(user_eg ${qhull_SHAREDR})
-    set_target_properties(user_eg PROPERTIES
-	COMPILE_DEFINITIONS "${user_eg_DEFINES}")
-else()
-    target_link_libraries(user_eg ${qhull_STATICR})
-endif()
-
-# ---------------------------------------
-# Define user_eg2 linked to reentrant qhull static library
-# ---------------------------------------
-
-add_executable(user_eg2 src/user_eg2/user_eg2_r.c)
-
-if(${BUILD_STATIC_LIBS})
-    target_link_libraries(user_eg2 ${qhull_STATICR})
-else()
-    target_link_libraries(user_eg2 ${qhull_SHAREDR})
-    set_target_properties(user_eg2 PROPERTIES
-	COMPILE_DEFINITIONS "${user_eg2_DEFINES}")
-endif()
-
-# ---------------------------------------
-# Define user_eg3 linked to qhullcpp and qhullstatic_r static libraries
-# 
-# user_eg3 is not defined for shared libraries
-#   user_eg3 and qhullcpp must be compiled with the same compiler for setjmp/longjmp
-# ---------------------------------------
-
-if(${BUILD_STATIC_LIBS})
-    add_executable(user_eg3 src/user_eg3/user_eg3_r.cpp)
-    # qhull_STATICR must be last, otherwise qh_fprintf,etc. are not loaded from qhull_CPP
-    target_link_libraries(user_eg3 ${qhull_CPP} ${qhull_STATICR})
-endif()
-
-# ---------------------------------------
-# qhullp is qhull/unix.c linked to unsupported qh_QHpointer libqhull_p
-# Included for testing qh_QHpointer 
-# ---------------------------------------
-
-add_executable(qhullp EXCLUDE_FROM_ALL src/qhull/unix.c)
-target_link_libraries(qhullp ${qhull_SHAREDP})
-set_target_properties(qhullp PROPERTIES
-    COMPILE_DEFINITIONS "${qhullp_DEFINES}")
-
-# ---------------------------------------
-# user_egp is user_eg/user_eg.c linked to unsupported qh_QHpointer libqhull_p
-# Included for compatibility with qhull-2012.1 
-# ---------------------------------------
-
-add_executable(user_egp EXCLUDE_FROM_ALL src/user_eg/user_eg.c)
-target_link_libraries(user_egp ${qhull_SHAREDP})
-set_target_properties(user_egp PROPERTIES
-    COMPILE_DEFINITIONS "${user_egp_DEFINES}")
 
 # ---------------------------------------
 # Define test
@@ -681,7 +684,9 @@ endif()
 # Define install
 # ---------------------------------------
 
-set(qhull_TARGETS_INSTALL ${qhull_TARGETS_APPLICATIONS})
+if(BUILD_APPLICATIONS)
+    set(qhull_TARGETS_INSTALL ${qhull_TARGETS_APPLICATIONS})
+endif()
 if (BUILD_SHARED_LIBS)
     list(APPEND qhull_TARGETS_INSTALL ${qhull_TARGETS_SHARED})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -684,13 +684,13 @@ endif()
 # Define install
 # ---------------------------------------
 
-if(BUILD_APPLICATIONS)
+if(${BUILD_APPLICATIONS})
     set(qhull_TARGETS_INSTALL ${qhull_TARGETS_APPLICATIONS})
 endif()
-if (BUILD_SHARED_LIBS)
+if(${BUILD_SHARED_LIBS})
     list(APPEND qhull_TARGETS_INSTALL ${qhull_TARGETS_SHARED})
 endif()
-if (BUILD_STATIC_LIBS)
+if(${BUILD_STATIC_LIBS})
     list(APPEND qhull_TARGETS_INSTALL ${qhull_TARGETS_STATIC})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ cmake_dependent_option(LINK_APPS_SHARED "Use shared library for linking applicat
     ${BUILD_SHARED_LIBS}
 )
 option(QHULL_ENABLE_TESTING "Build and run tests" ON)
+# BUILD_APPLICATIONS=OFF -- Do not build qhull applications
 option(BUILD_APPLICATIONS "Build applications" ON)
 
 if(INCLUDE_INSTALL_DIR)
@@ -522,130 +523,148 @@ endif()
 # If LINK_APPS_SHARED, applications are linked to reentrant qhull
 # ---------------------------------------
 
-if(BUILD_APPLICATIONS)
-    if(${LINK_APPS_SHARED})
-        add_executable(qconvex src/qconvex/qconvex_r.c)
-        target_link_libraries(qconvex ${qhull_SHAREDR})
-        set_target_properties(qconvex PROPERTIES
-            COMPILE_DEFINITIONS "${qconvex_DEFINES}")
+if(${LINK_APPS_SHARED})
+    add_executable(qconvex src/qconvex/qconvex_r.c)
+    target_link_libraries(qconvex ${qhull_SHAREDR})
+    set_target_properties(qconvex PROPERTIES
+        COMPILE_DEFINITIONS "${qconvex_DEFINES}")
 
-        add_executable(qdelaunay src/qdelaunay/qdelaun_r.c)
-        target_link_libraries(qdelaunay ${qhull_SHAREDR})
-        set_target_properties(qdelaunay PROPERTIES
-            COMPILE_DEFINITIONS "${qdelaunay_DEFINES}")
+    add_executable(qdelaunay src/qdelaunay/qdelaun_r.c)
+    target_link_libraries(qdelaunay ${qhull_SHAREDR})
+    set_target_properties(qdelaunay PROPERTIES
+        COMPILE_DEFINITIONS "${qdelaunay_DEFINES}")
 
-        add_executable(qhalf src/qhalf/qhalf_r.c)
-        target_link_libraries(qhalf ${qhull_SHAREDR})
-        set_target_properties(qhalf PROPERTIES
-            COMPILE_DEFINITIONS "${qhalf_DEFINES}")
+    add_executable(qhalf src/qhalf/qhalf_r.c)
+    target_link_libraries(qhalf ${qhull_SHAREDR})
+    set_target_properties(qhalf PROPERTIES
+        COMPILE_DEFINITIONS "${qhalf_DEFINES}")
 
-        add_executable(qhull src/qhull/unix_r.c)
-        target_link_libraries(qhull ${qhull_SHAREDR})
-        set_target_properties(qhull PROPERTIES
-            COMPILE_DEFINITIONS "${qhull_DEFINES}")
+    add_executable(qhull src/qhull/unix_r.c)
+    target_link_libraries(qhull ${qhull_SHAREDR})
+    set_target_properties(qhull PROPERTIES
+        COMPILE_DEFINITIONS "${qhull_DEFINES}")
 
-        add_executable(qvoronoi src/qvoronoi/qvoronoi_r.c)
-        target_link_libraries(qvoronoi ${qhull_SHAREDR})
-        set_target_properties(qvoronoi PROPERTIES
-            COMPILE_DEFINITIONS "${qvoronoi_DEFINES}")
+    add_executable(qvoronoi src/qvoronoi/qvoronoi_r.c)
+    target_link_libraries(qvoronoi ${qhull_SHAREDR})
+    set_target_properties(qvoronoi PROPERTIES
+        COMPILE_DEFINITIONS "${qvoronoi_DEFINES}")
 
-        add_executable(rbox src/rbox/rbox_r.c)
-        target_link_libraries(rbox ${qhull_SHAREDR})
-        set_target_properties(rbox PROPERTIES
-            COMPILE_DEFINITIONS "${rbox_DEFINES}")
-    else()
-        if(NOT ${BUILD_STATIC_LIBS})
-            message(FATAL_ERROR, " Nothing to build -- BUILD_SHARED_LIBS=OFF and BUILD_STATIC_LIBS=OFF")
-        endif()
-
-        add_executable(qconvex src/qconvex/qconvex.c)
-        target_link_libraries(qconvex ${qhull_STATIC})
-
-        add_executable(qdelaunay src/qdelaunay/qdelaun.c)
-        target_link_libraries(qdelaunay ${qhull_STATIC})
-
-        add_executable(qhalf src/qhalf/qhalf.c)
-        target_link_libraries(qhalf ${qhull_STATIC})
-
-        add_executable(qhull src/qhull/unix_r.c)
-        target_link_libraries(qhull ${qhull_STATICR})
-
-        add_executable(qvoronoi src/qvoronoi/qvoronoi.c)
-        target_link_libraries(qvoronoi ${qhull_STATIC})
-
-        add_executable(rbox src/rbox/rbox.c)
-        target_link_libraries(rbox ${qhull_STATIC})
+    add_executable(rbox src/rbox/rbox_r.c)
+    target_link_libraries(rbox ${qhull_SHAREDR})
+    set_target_properties(rbox PROPERTIES
+        COMPILE_DEFINITIONS "${rbox_DEFINES}")
+else()
+    if(NOT ${BUILD_STATIC_LIBS})
+        message(FATAL_ERROR, " Nothing to build -- BUILD_SHARED_LIBS=OFF and BUILD_STATIC_LIBS=OFF")
     endif()
 
-    # #@# 20
-    # ---------------------------------------
-    # Define testqset linked to qset.o, mem.o, and usermem.o
-    # Define testqset_r linked to qset_r.o, mem_r.o, and usermem.o
-    # ---------------------------------------
+    add_executable(qconvex src/qconvex/qconvex.c)
+    target_link_libraries(qconvex ${qhull_STATIC})
 
-    add_executable(testqset ${testqset_SOURCES})
-    add_executable(testqset_r ${testqsetr_SOURCES})
+    add_executable(qdelaunay src/qdelaunay/qdelaun.c)
+    target_link_libraries(qdelaunay ${qhull_STATIC})
 
-    # ---------------------------------------
-    # Define user_eg linked to reentrant qhull shared library
-    # ---------------------------------------
+    add_executable(qhalf src/qhalf/qhalf.c)
+    target_link_libraries(qhalf ${qhull_STATIC})
 
-    add_executable(user_eg src/user_eg/user_eg_r.c)
+    add_executable(qhull src/qhull/unix_r.c)
+    target_link_libraries(qhull ${qhull_STATICR})
 
-    if(${BUILD_SHARED_LIBS})
-        target_link_libraries(user_eg ${qhull_SHAREDR})
-        set_target_properties(user_eg PROPERTIES
-      COMPILE_DEFINITIONS "${user_eg_DEFINES}")
-    else()
-        target_link_libraries(user_eg ${qhull_STATICR})
-    endif()
+    add_executable(qvoronoi src/qvoronoi/qvoronoi.c)
+    target_link_libraries(qvoronoi ${qhull_STATIC})
 
-    # ---------------------------------------
-    # Define user_eg2 linked to reentrant qhull static library
-    # ---------------------------------------
+    add_executable(rbox src/rbox/rbox.c)
+    target_link_libraries(rbox ${qhull_STATIC})
+endif()
 
-    add_executable(user_eg2 src/user_eg2/user_eg2_r.c)
+# #@# 20
+# ---------------------------------------
+# Define testqset linked to qset.o, mem.o, and usermem.o
+# Define testqset_r linked to qset_r.o, mem_r.o, and usermem.o
+# ---------------------------------------
 
-    if(${BUILD_STATIC_LIBS})
-        target_link_libraries(user_eg2 ${qhull_STATICR})
-    else()
-        target_link_libraries(user_eg2 ${qhull_SHAREDR})
-        set_target_properties(user_eg2 PROPERTIES
-      COMPILE_DEFINITIONS "${user_eg2_DEFINES}")
-    endif()
+add_executable(testqset ${testqset_SOURCES})
+add_executable(testqset_r ${testqsetr_SOURCES})
 
-    # ---------------------------------------
-    # Define user_eg3 linked to qhullcpp and qhullstatic_r static libraries
-    # 
-    # user_eg3 is not defined for shared libraries
-    #   user_eg3 and qhullcpp must be compiled with the same compiler for setjmp/longjmp
-    # ---------------------------------------
+# ---------------------------------------
+# Define user_eg linked to reentrant qhull shared library
+# ---------------------------------------
 
-    if(${BUILD_STATIC_LIBS})
-        add_executable(user_eg3 src/user_eg3/user_eg3_r.cpp)
-        # qhull_STATICR must be last, otherwise qh_fprintf,etc. are not loaded from qhull_CPP
-        target_link_libraries(user_eg3 ${qhull_CPP} ${qhull_STATICR})
-    endif()
+add_executable(user_eg src/user_eg/user_eg_r.c)
 
-    # ---------------------------------------
-    # qhullp is qhull/unix.c linked to unsupported qh_QHpointer libqhull_p
-    # Included for testing qh_QHpointer 
-    # ---------------------------------------
+if(${BUILD_SHARED_LIBS})
+    target_link_libraries(user_eg ${qhull_SHAREDR})
+    set_target_properties(user_eg PROPERTIES
+  COMPILE_DEFINITIONS "${user_eg_DEFINES}")
+else()
+    target_link_libraries(user_eg ${qhull_STATICR})
+endif()
 
-    add_executable(qhullp EXCLUDE_FROM_ALL src/qhull/unix.c)
-    target_link_libraries(qhullp ${qhull_SHAREDP})
-    set_target_properties(qhullp PROPERTIES
-        COMPILE_DEFINITIONS "${qhullp_DEFINES}")
+# ---------------------------------------
+# Define user_eg2 linked to reentrant qhull static library
+# ---------------------------------------
 
-    # ---------------------------------------
-    # user_egp is user_eg/user_eg.c linked to unsupported qh_QHpointer libqhull_p
-    # Included for compatibility with qhull-2012.1 
-    # ---------------------------------------
+add_executable(user_eg2 src/user_eg2/user_eg2_r.c)
 
-    add_executable(user_egp EXCLUDE_FROM_ALL src/user_eg/user_eg.c)
-    target_link_libraries(user_egp ${qhull_SHAREDP})
-    set_target_properties(user_egp PROPERTIES
-        COMPILE_DEFINITIONS "${user_egp_DEFINES}")
+if(${BUILD_STATIC_LIBS})
+    target_link_libraries(user_eg2 ${qhull_STATICR})
+else()
+    target_link_libraries(user_eg2 ${qhull_SHAREDR})
+    set_target_properties(user_eg2 PROPERTIES
+  COMPILE_DEFINITIONS "${user_eg2_DEFINES}")
+endif()
+
+# ---------------------------------------
+# Define user_eg3 linked to qhullcpp and qhullstatic_r static libraries
+# 
+# user_eg3 is not defined for shared libraries
+#   user_eg3 and qhullcpp must be compiled with the same compiler for setjmp/longjmp
+# ---------------------------------------
+
+if(${BUILD_STATIC_LIBS})
+    add_executable(user_eg3 src/user_eg3/user_eg3_r.cpp)
+    # qhull_STATICR must be last, otherwise qh_fprintf,etc. are not loaded from qhull_CPP
+    target_link_libraries(user_eg3 ${qhull_CPP} ${qhull_STATICR})
+endif()
+
+# ---------------------------------------
+# qhullp is qhull/unix.c linked to unsupported qh_QHpointer libqhull_p
+# Included for testing qh_QHpointer 
+# ---------------------------------------
+
+add_executable(qhullp EXCLUDE_FROM_ALL src/qhull/unix.c)
+target_link_libraries(qhullp ${qhull_SHAREDP})
+set_target_properties(qhullp PROPERTIES
+    COMPILE_DEFINITIONS "${qhullp_DEFINES}")
+
+# ---------------------------------------
+# user_egp is user_eg/user_eg.c linked to unsupported qh_QHpointer libqhull_p
+# Included for compatibility with qhull-2012.1 
+# ---------------------------------------
+
+add_executable(user_egp EXCLUDE_FROM_ALL src/user_eg/user_eg.c)
+target_link_libraries(user_egp ${qhull_SHAREDP})
+set_target_properties(user_egp PROPERTIES
+    COMPILE_DEFINITIONS "${user_egp_DEFINES}")
+
+# ---------------------------------------
+# if BUILD_APPLICATIONS=OFF
+#   Exclude application builds from "make all" 
+# ---------------------------------------
+if(NOT ${BUILD_APPLICATIONS})
+    set_target_properties(qconvex PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    set_target_properties(qdelaunay PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    set_target_properties(qhalf PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    set_target_properties(qhull PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    set_target_properties(qvoronoi PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    set_target_properties(rbox PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    set_target_properties(testqset PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    set_target_properties(testqset_r PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    set_target_properties(user_eg PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    set_target_properties(user_eg2 PROPERTIES EXCLUDE_FROM_ALL TRUE)
+endif()
+if(NOT ${BUILD_APPLICATIONS} AND NOT ${BUILD_STATIC_LIBS})
+    set_target_properties(user_eg3 PROPERTIES EXCLUDE_FROM_ALL TRUE)
 endif()
 
 # ---------------------------------------


### PR DESCRIPTION
A new option `BUILD_APPLICATIONS` has been added, this defaults to `ON` and can be set to `OFF` if only libraries are needed and the tools themselves should not be built.