### PR TITLE
Revert "feat: Make CMake and PkgConfig install directory configurable."

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,14 +135,6 @@ if(DOC_INSTALL_DIR)
 else()
     set(DOC_INSTALL_DIR share/doc/qhull)
 endif()
-if(CMAKE_INSTALL_DIR)
-else()
-    set(CMAKE_INSTALL_DIR lib/cmake/QHull)
-endif()
-if(PKGCONFIG_INSTALL_DIR)
-else()
-    set(PKGCONFIG_INSTALL_DIR lib/pkgconfig)
-endif()
 message(STATUS)
 message(STATUS "========== qhull Build Information ==========")
 message(STATUS "Build Version:                             ${qhull_VERSION}")
@@ -152,8 +144,6 @@ message(STATUS "Library Directory (LIB_INSTALL_DIR):       ${LIB_INSTALL_DIR}")
 message(STATUS "Include Directory (INCLUDE_INSTALL_DIR):   ${INCLUDE_INSTALL_DIR}")
 message(STATUS "Documentation Directory (DOC_INSTALL_DIR): ${DOC_INSTALL_DIR}")
 message(STATUS "Man Pages Directory (MAN_INSTALL_DIR):     ${MAN_INSTALL_DIR}")
-message(STATUS "CMake Directory (CMAKE_INSTALL_DIR):       ${CMAKE_INSTALL_DIR}")
-message(STATUS "PkgConfig Directory (PKGCONFIG_INSTALL_DIR):${PKGCONFIG_INSTALL_DIR}")
 message(STATUS "Build Type (CMAKE_BUILD_TYPE):             ${CMAKE_BUILD_TYPE}")
 message(STATUS "Build static libraries:                    ${BUILD_STATIC_LIBS}")
 message(STATUS "Build shared library:                      ${BUILD_SHARED_LIBS}")
@@ -694,7 +684,7 @@ install(TARGETS ${qhull_TARGETS_INSTALL} EXPORT QhullTargets
         BUNDLE DESTINATION ${BIN_INSTALL_DIR}
         LIBRARY DESTINATION ${LIB_INSTALL_DIR}
         ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
-        INCLUDES DESTINATION ${INCLUDE_INSTALL_DIR})
+        INCLUDES DESTINATION include)
 
 include(CMakePackageConfigHelpers)
 
@@ -714,7 +704,7 @@ configure_file(${PROJECT_SOURCE_DIR}/build/config.cmake.in
   @ONLY
 )
 
-set(ConfigPackageLocation ${CMAKE_INSTALL_DIR})
+set(ConfigPackageLocation lib/cmake/Qhull)
 install(EXPORT QhullTargets
   FILE
     QhullTargets.cmake
@@ -733,7 +723,7 @@ install(
     Devel
 )
 
-set(PkgConfigLocation ${PKGCONFIG_INSTALL_DIR})
+set(PkgConfigLocation lib/pkgconfig)
 foreach(pkgconfig IN ITEMS "${qhull_SHAREDR};Qhull reentrant shared library"
                            "${qhull_STATIC};Qhull static library"
                            "${qhull_STATICR};Qhull reentrant static library"


### PR DESCRIPTION
Revert qhull/qhull#113  in order to merge #123.   It uses LIB_INSTALL_DIR to customize install directories for cmake and pkgconfig.

Your fix to 'INCLUDES DESTINATION include)' will be edited by hand.  Good catch.

