### PR TITLE
fix typos

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -545,10 +545,10 @@ src/
   qhulltest/qhulltest.cpp // Test of Qhull's C++ interface using Qt's QTestLib
   qhull-*.pri             // Include files for Qt projects
   testqset_r/testqset_r.c  // Test of reentrant qset_r.c and mem_r.c
-  testqset/testqset.c     // Test of non-rentrant qset.c and mem.c
+  testqset/testqset.c     // Test of non-reentrant qset.c and mem.c
 
 src/libqhull
-  libqhull.pro         // Qt project for non-rentrant, shared library (qhull.dll)
+  libqhull.pro         // Qt project for non-reentrant, shared library (qhull.dll)
   index.htm            // design documentation for libqhull
   qh-*.htm
   qhull-exports.def    // Export Definition files for Visual C++
@@ -589,7 +589,7 @@ src/libqhull
   stat.h
 
 src/libqhull_r
-  libqhull_r.pro       // Qt project for rentrant, shared library (qhull_r.dll)
+  libqhull_r.pro       // Qt project for reentrant, shared library (qhull_r.dll)
   index.htm            // design documentation for libqhull_r
   qh-*_r.htm
   qhull_r-exports.def  // Export Definition files for Visual C++
@@ -626,7 +626,7 @@ src/libqhull_r
   stat.h
 
 src/libqhullcpp/
-  libqhullcpp.pro      // Qt project for renentrant, static C++ library     
+  libqhullcpp.pro      // Qt project for reentrant, static C++ library     
   Qhull.cpp            // Calls libqhull_r.c from C++
   Qhull.h
   qt-qhull.cpp         // Supporting methods for Qt

--- a/build/README-build.txt
+++ b/build/README-build.txt
@@ -16,7 +16,7 @@ This directory contains
   build/CMakeModules/CheckLFS.cmake // enables Large File Support in CMake
 
 The following build targets are _deprecated_ and are not included in the Qhull builds
-  build/libqhull-??.vcxproj // Non-rentrant Qhull
+  build/libqhull-??.vcxproj // Non-reentrant Qhull
   build/libqhull.vcproj     //   Replaced by qhullstatic
   src/libqhull/libqhull.pro
   CMakeLists.txt#libqhull

--- a/eg/make-vcproj.sh
+++ b/eg/make-vcproj.sh
@@ -4,7 +4,7 @@
 #       eg/make-vcproj.sh qhull-x -- Derive src/qhull-x/ from src/libqhull_r
 #
 # Design
-#       CMake vcproj files includes absolute paths and does not handle 'd' annotatios for debug versions
+#       CMake vcproj files includes absolute paths and does not handle 'd' annotations for debug versions
 #       Remove CMake targets
 #       Change absolute paths to '../..'
 #       Append '_d' to debug products

--- a/eg/q_test-ok.txt
+++ b/eg/q_test-ok.txt
@@ -14775,7 +14775,7 @@ qhull(1)                                                 qhull(1)
        d Qu   Compute the  furthest-site  Delaunay  triangulation
               from  the upper convex hull.  The 'o' option prints
               the input points and facets.  The 'QJ' option guar-
-              antees triangular otuput.  You can also use facets.
+              antees triangular output.  You can also use facets.
 
        v Qu   Compute the furthest-site Voronoi diagram.  The 'p'
               option prints the Voronoi vertices.  The 'o' option

--- a/html/index.htm
+++ b/html/index.htm
@@ -647,7 +647,7 @@ and see how Qhull produces thick facets in response to round-off error.
 <li>Click 'Filter' in the files panel to view your examples in the 'Files' list.
 <li>Load another example into the camera window by selecting it and clicking 'OK'.
 <li>Review the instructions for <a href="http://www.geomview.org/docs/html/Interaction.html">Interacting with Geomview</a>
-<li>When viewing multiple objects at once, you may want to turn off normalization.  In the 'Inspect > Apperance' control panel, set 'Normalize' to 'None'.
+<li>When viewing multiple objects at once, you may want to turn off normalization.  In the 'Inspect > Appearance' control panel, set 'Normalize' to 'None'.
 </ul>
 </ol>
 
@@ -879,7 +879,7 @@ Cambridge University Press, 2001.
 
 <p><a name="gart99">Gartner, B.</a>, "Fast and robust smallest enclosing balls", <i>Algorithms - ESA '99</i>, LNCS 1643.
 
-<p><a name="golub83">Golub, G.H. and van Loan, C.F.</a>, <i>Matric Computations</i>, Baltimore, Maryland, USA: John Hopkins Press, 1983
+<p><a name="golub83">Golub, G.H. and van Loan, C.F.</a>, <i>Matrix Computations</i>, Baltimore, Maryland, USA: John Hopkins Press, 1983
 
 <p><a name="fort93">Fortune, S.</a>, &quot;Computational
 geometry,&quot; in R. Martin, editor, <i>Directions in Geometric

--- a/html/qdelaun.htm
+++ b/html/qdelaun.htm
@@ -240,7 +240,7 @@ outputs</a></h3>
         remaining lines list the input sites for each region.  The regions are
                 oriented.  In 3-d and
         higher, report cospherical sites by adding extra points.  Use triangulated
-        output ('<a href="qh-optq.htm#Qt">Qt</a>') to avoid non-simpicial regions.  For the circle-in-square example,
+        output ('<a href="qh-optq.htm#Qt">Qt</a>') to avoid non-simplicial regions.  For the circle-in-square example,
         eight Delaunay regions are triangular and the ninth has four input sites.</dd>
     <dt><a href="qh-optf.htm#Fv">Fv</a></dt>
     <dd>list input sites for each Delaunay region.  The first line is the number of regions.

--- a/html/qh-code.htm
+++ b/html/qh-code.htm
@@ -164,7 +164,7 @@ or another directory comparison utility.
 <li>Almost all unmodified lines should be identical.
 <li>Use 'Diffs' view to review diffs, and 'All' view to copy diffs.  Otherwise wrong lines may be changed
 <li>Copy modified lines as needed.
-<li>Be careful of removing true differences, such as those involiving
+<li>Be careful of removing true differences, such as those involving
 <ul>
 <li>DEFqhT
 <li>oldqhA, oldqhB
@@ -175,7 +175,7 @@ or another directory comparison utility.
 <li>qhstat, qhstatT
 <li>rbox_inuse
 <li>rboxT
-<li>"renentrant" vs. "non-reentrant"
+<li>"reentrant" vs. "non-reentrant"
 </ul>
 </ul>
 
@@ -838,7 +838,7 @@ Use 'qhull --help' instead.
 '<a href="qh-optt.htm#TFn">TFn</a>'.   Qhull normally takes approximately the same amount of time per point.
 If the output is too large, it will slow down due to main memory or virtual memory.
 <li>If there are large,
-non-simplicial facets, see "quadradic running time" in <a href="qh-impre.htm#limit">Limitations of merged facets</a>.
+non-simplicial facets, see "quadratic running time" in <a href="qh-impre.htm#limit">Limitations of merged facets</a>.
 <li>See <a href="#performance">Performance</a> and <a href="#loops">infinite loops</a> for further suggestions.
 </ul>
 
@@ -1274,7 +1274,7 @@ Top Suggestions
  - Write incremental addPoint with bucketed inputs and facet search (CGAL)
  - Compute hyperplanes in parallel (cf. qh_setfactplane)
  - Create Voronoi volumes and topology in parallel
- - Implement Delaunay to Voronoi tesselation [Peterka et al, 2014, www.mcs.anl.gov/papers/P5154-0614.pdf]
+ - Implement Delaunay to Voronoi tessellation [Peterka et al, 2014, www.mcs.anl.gov/papers/P5154-0614.pdf]
  - Integrate 4dview with Geomview 1.9.5
  - Use coverage testing to expand Qhull's test programs
  - Add RPM and Debian builds to Qhull (CMake's CPackRMP and CPackDeb).

--- a/html/qh-optq.htm
+++ b/html/qh-optq.htm
@@ -453,7 +453,7 @@ facets).  Each facet is non-simplicial because it has four vertices.
 
 <p>Use option 'Qt' to triangulate all non-simplicial facets before generating
 results.  Alternatively, use joggled input ('<a href="#QJn">QJ</a>') to
-prevent non-simplical facets.  Unless '<a href="qh-optp.htm#Pp">Pp</a>' is set,
+prevent non-simplicial facets.  Unless '<a href="qh-optp.htm#Pp">Pp</a>' is set,
 qhull produces a warning if 'QJ' and 'Qt' are used together.
 
 <p>For Delaunay triangulations (<a href=qdelaun.htm>qdelaunay</a>), triangulation

--- a/html/qhull.man
+++ b/html/qhull.man
@@ -222,7 +222,7 @@ option produces a feasible point for a convex hull.
 d Qu
 Compute the furthest\[hy]site Delaunay triangulation from the upper
 convex hull.  The 'o' option prints the input points and facets.
-The 'QJ' option guarantees triangular otuput.  You can also use 'Ft'
+The 'QJ' option guarantees triangular output.  You can also use 'Ft'
 to triangulate via the centrums of non\[hy]simplicial
 facets.
 .TP

--- a/html/qhull.txt
+++ b/html/qhull.txt
@@ -258,7 +258,7 @@ qhull(1)                                                 qhull(1)
        d Qu   Compute the  furthest-site  Delaunay  triangulation
               from  the upper convex hull.  The 'o' option prints
               the input points and facets.  The 'QJ' option guar-
-              antees triangular otuput.  You can also use facets.
+              antees triangular output.  You can also use facets.
 
        v Qu   Compute the furthest-site Voronoi diagram.  The 'p'
               option prints the Voronoi vertices.  The 'o' option

--- a/index.htm
+++ b/index.htm
@@ -185,7 +185,7 @@ geometry programs and other combinatorial algorithms
         href="http://www.robertschneiders.de/meshgeneration/meshgeneration.html">
         Finite Element</a> Mesh Generation page</li>
      <li>Shewchuk's <a href="http://www.cs.cmu.edu/~quake/triangle.html">triangle</a> program for 2-d Delaunay</li>
-     <li>Teillaud's <a href="http://www.computational-geometry.org/">Computional Geometry Pages</a> for the Society of Computational Geometry and academic conferences.
+     <li>Teillaud's <a href="http://www.computational-geometry.org/">Computational Geometry Pages</a> for the Society of Computational Geometry and academic conferences.
         <li>Tomilov's <a href="https://github.com/tomilov/quickhull/blob/master/include/quickhull.hpp">quickhull.hpp</a> (<a href="http://habrahabr.ru/post/245221/">doc-ru</a>) implements the Quickhull algorithm for points in general position.
         <li>Young's <a href="http://homepage.usask.ca/~ijm451/finite/fe_resources/">Internet Finite Element Resources</a>
         <li>Zolotykh's <a href="http://www.uic.unn.ru/~zny/skeleton/">Skeleton</a> generates all extreme rays of a polyhedral cone using the Double Description Method</li>

--- a/src/Changes.txt
+++ b/src/Changes.txt
@@ -185,7 +185,7 @@ Documentation
 - index.htm: Balance the top-page 'URL:' and 'To:' links
 - index.htm: Send the top-page 'Functions' link to www.qhull.org (better 'src' links)
 - index.htm: Make the bottom-page 'URL:' and 'To:' links the same as the top-page links
-- index.htm: "please use rentrant Qhull (libqhull_r or libqhullstatic_r)"
+- index.htm: "please use reentrant Qhull (libqhull_r or libqhullstatic_r)"
 - html/index.htm: Add rbox.txt to Contents and rename "Table of Contents"
 - html/index.htm,qh-code.htm,qh-eg.htm,qh-impre.htm: Remove 'please wait while loading'
 - README.txt/Installing Qhull with Qt: The shadow build directory should be at the same level as 'src'
@@ -1369,7 +1369,7 @@ C++ interface by class
  - Coordinates
    Removed empty().  Use isEmpty() instead
    Added append(dim, coordT*)
-   Reformated the iterators
+   Reformatted the iterators
    Convert to countT
  - PointCoordinates
    Added constructors for Qhull or QhullQh* (provides access to QhullPoint.operator==)
@@ -1832,7 +1832,7 @@ qhull 2010.1 2010/01/06
 - First release of C++ interface [qh-code.htm]
 - Development moved to http://gitorious.org/qhull
   git clone git@gitorious.org:qhull/qhull.git
-- Did not fix conformant tesselations for 'Qt'.
+- Did not fix conformant tessellations for 'Qt'.
   For details, see http://www.qhull.org/news#bugs of May 2007 and Dec 2006.
 - Use g++ builds for Windows distribution (10% faster than msvc2005)
   Combined vcproj/ and qtproj/ into project/
@@ -2619,7 +2619,7 @@ qhull V2.3 96/3/25
  - fixed false error if 'Tc', coplanar points, and a narrow hull
  - turn off 'Rn' when computing statistics, checking code, or tracing code
  - removed ={0} from global.c and stat.c to reduce compiler warnings
- - changed Makefile dependences to $(HFILES) for all but unix.o, set.o, mem.o
+ - changed Makefile dependencies to $(HFILES) for all but unix.o, set.o, mem.o
  - pulled out qh_printpointid and reordered qh_pointid [E. Voth]
  - removed some compiler warnings
  - moved 'FO' print of options to just before qh_buildhull
@@ -3090,7 +3090,7 @@ Converting from qhull 1.01 to qhull 2.00
   - 'qhull o' is now 'qhull Po'
   - 'qhull b' is now always done
   - qhull and rbox now use floats, change REALfloat in libqhull.h for doubles
-  - qhull 2.00 fixes several initialization errors and performanace errors
+  - qhull 2.00 fixes several initialization errors and performance errors
         e.g., "singular input" on data with lots of 0 coordinates
   - 'rbox b' is now 'rbox c G0.48'
   - all rbox distributions are now scaled to a 0.5 box (use 'Bn' to change)

--- a/src/libqhull/io.c
+++ b/src/libqhull/io.c
@@ -3748,7 +3748,7 @@ coordT *qh_readpoints(int *numpoints, int *dimension, boolT *ismalloc) {
         strncat(qh rbox_command, s, sizeof(qh rbox_command)-1);
     }
     if (!s) {
-      qh_fprintf(qh ferr, 6074, "qhull input error: missing \"begin\" for cdd-formated input\n");
+      qh_fprintf(qh ferr, 6074, "qhull input error: missing \"begin\" for cdd-formatted input\n");
       qh_errexit(qh_ERRinput, NULL, NULL);
     }
   }

--- a/src/libqhull/libqhull.h
+++ b/src/libqhull/libqhull.h
@@ -831,7 +831,7 @@ struct qhT {
   >--------------------------------</a><a name="qh-buf">-</a>
 
   qh global buffers
-    defines buffers for maxtrix operations, input, and error messages
+    defines buffers for matrix operations, input, and error messages
 */
   coordT *gm_matrix;      /* (dim+1)Xdim matrix for geom.c */
   coordT **gm_row;        /* array of gm_matrix rows */

--- a/src/libqhull/mem.h
+++ b/src/libqhull/mem.h
@@ -96,9 +96,9 @@ typedef long ptr_intT;
    users should ignore qhmem except for writing extensions
    qhmem is allocated in mem.c
 
-   qhmem could be swapable like qh and qhstat, but then
+   qhmem could be swappable like qh and qhstat, but then
    multiple qh's and qhmem's would need to keep in synch.
-   A swapable qhmem would also waste memory buffers.  As long
+   A swappable qhmem would also waste memory buffers.  As long
    as memory operations are atomic, there is no problem with
    multiple qh structures being active at the same time.
    If you need separate address spaces, you can swap the

--- a/src/libqhull/poly.c
+++ b/src/libqhull/poly.c
@@ -909,7 +909,7 @@ void qh_matchneighbor(facetT *newfacet, int newskip, int hashsize, int *hashcoun
         vertices for the nth neighbor match all but the nth vertex
     if not merging and qh.FORCEoutput
       for facets with normals (i.e., with dupridges)
-      sets facet->flippped for flipped normals, also prevents point partitioning
+      sets facet->flipped for flipped normals, also prevents point partitioning
 
   notes:
     called by qh_buildcone* and qh_triangulate_facet

--- a/src/libqhull/poly2.c
+++ b/src/libqhull/poly2.c
@@ -688,7 +688,7 @@ void qh_checkconvex(facetT *facetlist, int fault) {
     if non-simplicial, at least as many ridges as neighbors
     neighbors are not duplicated
     ridges are not duplicated
-    in 3-d, ridges=verticies
+    in 3-d, ridges=vertices
     (qh.hull_dim-1) ridge vertices
     neighbors are reciprocated
     ridge neighbors are facet neighbors and a ridge for every neighbor

--- a/src/libqhull/random.c
+++ b/src/libqhull/random.c
@@ -2,7 +2,7 @@
   >-------------------------------</a><a name="TOP">-</a>
 
    random.c and utilities
-     Park & Miller's minimimal standard random number generator
+     Park & Miller's minimal standard random number generator
      argc/argv conversion
 
      Used by rbox.  Do not use 'qh' 

--- a/src/libqhull/user.h
+++ b/src/libqhull/user.h
@@ -523,7 +523,7 @@ try twice at the original value in case of bad luck the first time
     default box size (Geomview expects 0.5)
 
   qh_DEFAULTbox
-    default box size for integer coorindate (rbox only)
+    default box size for integer coordinate (rbox only)
 */
 #define qh_DEFAULTbox 0.5
 #define qh_DEFAULTzbox 1e6

--- a/src/libqhull_r/io_r.c
+++ b/src/libqhull_r/io_r.c
@@ -3748,7 +3748,7 @@ coordT *qh_readpoints(qhT *qh, int *numpoints, int *dimension, boolT *ismalloc) 
         strncat(qh->rbox_command, s, sizeof(qh->rbox_command)-1);
     }
     if (!s) {
-      qh_fprintf(qh, qh->ferr, 6074, "qhull input error: missing \"begin\" for cdd-formated input\n");
+      qh_fprintf(qh, qh->ferr, 6074, "qhull input error: missing \"begin\" for cdd-formatted input\n");
       qh_errexit(qh, qh_ERRinput, NULL, NULL);
     }
   }

--- a/src/libqhull_r/libqhull_r.h
+++ b/src/libqhull_r/libqhull_r.h
@@ -800,7 +800,7 @@ struct qhT {
   >--------------------------------</a><a name="qh-buf">-</a>
 
   qh global buffers
-    defines buffers for maxtrix operations, input, and error messages
+    defines buffers for matrix operations, input, and error messages
 */
   coordT *gm_matrix;      /* (dim+1)Xdim matrix for geom_r.c */
   coordT **gm_row;        /* array of gm_matrix rows */

--- a/src/libqhull_r/mem_r.h
+++ b/src/libqhull_r/mem_r.h
@@ -106,9 +106,9 @@ typedef long ptr_intT;
    users should ignore qhmem except for writing extensions
    qhmem is allocated in mem_r.c
 
-   qhmem could be swapable like qh and qhstat, but then
+   qhmem could be swappable like qh and qhstat, but then
    multiple qh's and qhmem's would need to keep in synch.
-   A swapable qhmem would also waste memory buffers.  As long
+   A swappable qhmem would also waste memory buffers.  As long
    as memory operations are atomic, there is no problem with
    multiple qh structures being active at the same time.
    If you need separate address spaces, you can swap the

--- a/src/libqhull_r/poly2_r.c
+++ b/src/libqhull_r/poly2_r.c
@@ -689,7 +689,7 @@ void qh_checkconvex(qhT *qh, facetT *facetlist, int fault) {
     if non-simplicial, at least as many ridges as neighbors
     neighbors are not duplicated
     ridges are not duplicated
-    in 3-d, ridges=verticies
+    in 3-d, ridges=vertices
     (qh.hull_dim-1) ridge vertices
     neighbors are reciprocated
     ridge neighbors are facet neighbors and a ridge for every neighbor

--- a/src/libqhull_r/random_r.c
+++ b/src/libqhull_r/random_r.c
@@ -2,7 +2,7 @@
   >-------------------------------</a><a name="TOP">-</a>
 
    random_r.c and utilities
-     Park & Miller's minimimal standard random number generator
+     Park & Miller's minimal standard random number generator
      argc/argv conversion
 
      Used by rbox.  Do not use 'qh' 

--- a/src/libqhull_r/user_r.h
+++ b/src/libqhull_r/user_r.h
@@ -522,7 +522,7 @@ try twice at the original value in case of bad luck the first time
     default box size (Geomview expects 0.5)
 
   qh_DEFAULTbox
-    default box size for integer coorindate (rbox only)
+    default box size for integer coordinate (rbox only)
 */
 #define qh_DEFAULTbox 0.5
 #define qh_DEFAULTzbox 1e6

--- a/src/testqset/testqset.c
+++ b/src/testqset/testqset.c
@@ -93,9 +93,9 @@ enum {
     MAXint= 0x7fffffff
 };
 
-char prompt[]= "testqset N [M] [T5] -- Test non-rentrant qset.c and mem.c\n\
+char prompt[]= "testqset N [M] [T5] -- Test non-reentrant qset.c and mem.c\n\
   \n\
-  If this test fails then non-rentrant Qhull will not work.\n\
+  If this test fails then non-reentrant Qhull will not work.\n\
   \n\
   Test qsets of 0..N integers with a check every M iterations (default ~log10)\n\
   Additional checking and logging if M is 1\n\

--- a/src/user_eg/user_eg.c
+++ b/src/user_eg/user_eg.c
@@ -204,7 +204,7 @@ int main(int argc, char *argv[]) {
   printf("\n========\nuser_eg 'cube qhull options' 'Delaunay options' 'halfspace options'\n\
 \n\
 This is the output from user_eg.c.  It shows how qhull() may be called from\n\
-an application, via Qhull's shared, non-rentrant library.  user_eg is not part of\n\
+an application, via Qhull's shared, non-reentrant library.  user_eg is not part of\n\
 Qhull itself.  If user_eg fails immediately, user_eg.c was incorrectly linked\n\
 to Qhull's reentrant library, libqhull_r.\n\
 Try -- user_eg 'T1' 'T1' 'T1'\n\


### PR DESCRIPTION
dumped repo strings exposed a few typos

<hr>

`https://github.com/scipy/scipy`

someone took up the unproductive task of typo corrections of the bundled code over in SciPy