### PR TITLE
Remove duplicate declarations

### DIFF
--- a/src/libqhull_r/libqhull_r.h
+++ b/src/libqhull_r/libqhull_r.h
@@ -1149,7 +1149,6 @@ facetT *qh_findbestnew(qhT *qh, pointT *point, facetT *startfacet,
                      realT *dist, boolT bestoutside, boolT *isoutside, int *numpart);
 boolT   qh_gram_schmidt(qhT *qh, int dim, realT **rows);
 void    qh_outerinner(qhT *qh, facetT *facet, realT *outerplane, realT *innerplane);
-void    qh_printsummary(qhT *qh, FILE *fp);
 void    qh_projectinput(qhT *qh);
 void    qh_randommatrix(qhT *qh, realT *buffer, int dim, realT **row);
 void    qh_rotateinput(qhT *qh, realT **rows);
@@ -1189,11 +1188,6 @@ void    qh_produce_output(qhT *qh);
 coordT *qh_readpoints(qhT *qh, int *numpoints, int *dimension, boolT *ismalloc);
 
 
-/********* -mem_r.c prototypes (duplicated from mem_r.h) **********************/
-
-void qh_meminit(qhT *qh, FILE *ferr);
-void qh_memfreeshort(qhT *qh, int *curlong, int *totlong);
-
 /********* -poly_r.c/poly2_r.c prototypes (duplicated from poly_r.h) **********************/
 
 void    qh_check_output(qhT *qh);
@@ -1212,11 +1206,6 @@ void    qh_triangulate(qhT *qh /* qh.facet_list */);
 /********* -rboxlib_r.c prototypes **********************/
 int     qh_rboxpoints(qhT *qh, char* rbox_command);
 void    qh_errexit_rbox(qhT *qh, int exitcode);
-
-/********* -stat_r.c prototypes (duplicated from stat_r.h) **********************/
-
-void    qh_collectstatistics(qhT *qh);
-void    qh_printallstatistics(qhT *qh, FILE *fp, const char *string);
 
 /************************** accessors.c prototypes ******************************/
 


### PR DESCRIPTION
qh_printsummary is already declared a few lines above, and is *not* implemented one of the mentioned c files.

Both mem_r.h and stat_r.h are unconditionally included in libqhull_r.h, thus it does not make sense to provide these selected declarations again.

Fixes #78.