### PR TITLE
fix: ensure that %p format specifiers are used with (void *) pointers

### DIFF
--- a/src/libqhull/global.c
+++ b/src/libqhull/global.c
@@ -2326,7 +2326,7 @@ void qh_restore_qhull(qhT **oldqh) {
 
   if (*oldqh && strcmp((*oldqh)->qhull, "qhull")) {
     qh_fprintf(qhmem.ferr, 6061, "qhull internal error (qh_restore_qhull): %p is not a qhull data structure\n",
-                  *oldqh);
+                  (void *) *oldqh);
     qh_errexit(qh_ERRqhull, NULL, NULL);
   }
   if (qh_qh) {
@@ -2335,7 +2335,7 @@ void qh_restore_qhull(qhT **oldqh) {
   }
   if (!*oldqh || !(*oldqh)->old_qhstat) {
     qh_fprintf(qhmem.ferr, 6063, "qhull internal error (qh_restore_qhull): did not previously save qhull %p\n",
-                  *oldqh);
+                  (void *) *oldqh);
     qh_errexit(qh_ERRqhull, NULL, NULL);
   }
   qh_qh= *oldqh;
@@ -2344,7 +2344,7 @@ void qh_restore_qhull(qhT **oldqh) {
   qhmem.tempstack= qh old_tempstack;
   qh old_qhstat= 0;
   qh old_tempstack= 0;
-  trace1((qh ferr, 1007, "qh_restore_qhull: restored qhull from %p\n", *oldqh));
+  trace1((qh ferr, 1007, "qh_restore_qhull: restored qhull from %p\n", (void *) *oldqh));
 } /* restore_qhull */
 
 /*-<a                             href="qh-globa.htm#TOC"
@@ -2370,7 +2370,7 @@ void qh_restore_qhull(qhT **oldqh) {
 qhT *qh_save_qhull(void) {
   qhT *oldqh;
 
-  trace1((qhmem.ferr, 1045, "qh_save_qhull: save qhull %p\n", qh_qh));
+  trace1((qhmem.ferr, 1045, "qh_save_qhull: save qhull %p\n", (void *) qh_qh));
   if (!qh_qh) {
     qh_fprintf(qhmem.ferr, 6064, "qhull internal error (qh_save_qhull): qhull not initialized\n");
     qh_errexit(qh_ERRqhull, NULL, NULL);

--- a/src/libqhull/merge.c
+++ b/src/libqhull/merge.c
@@ -428,7 +428,7 @@ void qh_appendmergeset(facetT *facet, facetT *neighbor, mergeType mergetype, coo
   }
   if (!qh facet_mergeset || !qh degen_mergeset) {
     qh_fprintf(qh ferr, 6403, "qhull internal error (qh_appendmergeset): expecting temp set defined for qh.facet_mergeset (%p) and qh.degen_mergeset (%p).  Got NULL\n",
-      qh facet_mergeset, qh degen_mergeset);
+      (void *) qh facet_mergeset, (void *) qh degen_mergeset);
     /* otherwise qh_setappend creates a new set that is not freed by qh_freebuild() */
     qh_errexit(qh_ERRqhull, NULL, NULL);
   }
@@ -1654,7 +1654,7 @@ void qh_freemergesets(void) {
 
   if (!qh facet_mergeset || !qh degen_mergeset || !qh vertex_mergeset) {
     qh_fprintf(qh ferr, 6388, "qhull internal error (qh_freemergesets): expecting mergesets.  Got a NULL mergeset, qh.facet_mergeset (%p), qh.degen_mergeset (%p), qh.vertex_mergeset (%p)\n",
-      qh facet_mergeset, qh degen_mergeset, qh vertex_mergeset);
+      (void *) qh facet_mergeset, (void *) qh degen_mergeset, (void *) qh vertex_mergeset);
     qh_errexit(qh_ERRqhull, NULL, NULL);
   }
   if (!SETempty_(qh facet_mergeset) || !SETempty_(qh degen_mergeset) || !SETempty_(qh vertex_mergeset)) {
@@ -2034,7 +2034,7 @@ void qh_initmergesets(void /* qh.facet_mergeset,degen_mergeset,vertex_mergeset *
 
   if (qh facet_mergeset || qh degen_mergeset || qh vertex_mergeset) {
     qh_fprintf(qh ferr, 6386, "qhull internal error (qh_initmergesets): expecting NULL mergesets.  Got qh.facet_mergeset (%p), qh.degen_mergeset (%p), qh.vertex_mergeset (%p)\n",
-      qh facet_mergeset, qh degen_mergeset, qh vertex_mergeset);
+      (void *) qh facet_mergeset, (void *) qh degen_mergeset, (void *) qh vertex_mergeset);
     qh_errexit(qh_ERRqhull, NULL, NULL);
   }
   qh degen_mergeset= qh_settemp(qh TEMPsize);
@@ -3881,7 +3881,7 @@ void qh_mergevertex_neighbors(facetT *facet1, facetT *facet2) {
           facet1->id, facet2->id));
   if (qh tracevertex) {
     qh_fprintf(qh ferr, 8081, "qh_mergevertex_neighbors: of f%d into f%d at furthest p%d f0= %p\n",
-             facet1->id, facet2->id, qh furthest_id, qh tracevertex->neighbors->e[0].p);
+             facet1->id, facet2->id, qh furthest_id, (void *) qh tracevertex->neighbors->e[0].p);
     qh_errprint("TRACE", NULL, NULL, NULL, qh tracevertex);
   }
   FOREACHvertex_(facet1->vertices) {

--- a/src/libqhull/poly2.c
+++ b/src/libqhull/poly2.c
@@ -1297,7 +1297,7 @@ void qh_checkpolygon(facetT *facetlist) {
         numvertices++;
         if (qh_pointid(vertex->point) == qh_IDunknown) {
           qh_fprintf(qh ferr, 6139, "qhull internal error (qh_checkpolygon): unknown point %p for vertex v%d first_point %p\n",
-                   vertex->point, vertex->id, qh first_point);
+                   (void *) vertex->point, vertex->id, (void *) qh first_point);
           waserror= True;
         }
       }
@@ -1405,7 +1405,7 @@ void qh_checkvertex(vertexT *vertex, boolT allchecks, boolT *waserrorp) {
   facetT *neighbor, **neighborp, *errfacet=NULL;
 
   if (qh_pointid(vertex->point) == qh_IDunknown) {
-    qh_fprintf(qh ferr, 6144, "qhull internal error (qh_checkvertex): unknown point id %p\n", vertex->point);
+    qh_fprintf(qh ferr, 6144, "qhull internal error (qh_checkvertex): unknown point id %p\n", (void *) vertex->point);
     waserror= True;
   }
   if (vertex->id >= qh vertex_id) {
@@ -3115,7 +3115,7 @@ void qh_point_add(setT *set, pointT *point, void *elem) {
   SETreturnsize_(set, size);
   if ((id= qh_pointid(point)) < 0)
     qh_fprintf(qh ferr, 7067, "qhull internal warning (point_add): unknown point %p id %d\n",
-      point, id);
+      (void *) point, id);
   else if (id >= size) {
     qh_fprintf(qh ferr, 6160, "qhull internal error (point_add): point p%d is out of bounds(%d)\n",
              id, size);

--- a/src/libqhull/qset.c
+++ b/src/libqhull/qset.c
@@ -1096,11 +1096,11 @@ void qh_setprint(FILE *fp, const char* string, setT *set) {
   else {
     SETreturnsize_(set, size);
     qh_fprintf(fp, 9347, "%s set=%p maxsize=%d size=%d elems=",
-             string, set, set->maxsize, size);
+             string, (void *) set, set->maxsize, size);
     if (size > set->maxsize)
       size= set->maxsize+1;
     for (k=0; k < size; k++)
-      qh_fprintf(fp, 9348, " %p", set->e[k].p);
+      qh_fprintf(fp, 9348, " %p", (void *) set->e[k].p);
     qh_fprintf(fp, 9349, "\n");
   }
 } /* setprint */
@@ -1193,7 +1193,7 @@ setT *qh_settemp(int setsize) {
   qh_setappend(&qhmem.tempstack, newset);
   if (qhmem.IStracing >= 5)
     qh_fprintf(qhmem.ferr, 8123, "qh_settemp: temp set %p of %d elements, depth %d\n",
-       newset, newset->maxsize, qh_setsize(qhmem.tempstack));
+       (void *) newset, newset->maxsize, qh_setsize(qhmem.tempstack));
   return newset;
 } /* settemp */
 
@@ -1223,8 +1223,8 @@ void qh_settempfree(setT **set) {
   if (stackedset != *set) {
     qh_settemppush(stackedset);
     qh_fprintf(qhmem.ferr, 6179, "qhull internal error (qh_settempfree): set %p(size %d) was not last temporary allocated(depth %d, set %p, size %d)\n",
-             *set, qh_setsize(*set), qh_setsize(qhmem.tempstack)+1,
-             stackedset, qh_setsize(stackedset));
+             (void *) *set, qh_setsize(*set), qh_setsize(qhmem.tempstack)+1,
+             (void *) stackedset, qh_setsize(stackedset));
     qh_errexit(qhmem_ERRqhull, NULL, NULL);
   }
   qh_setfree(set);
@@ -1271,7 +1271,7 @@ setT *qh_settemppop(void) {
   }
   if (qhmem.IStracing >= 5)
     qh_fprintf(qhmem.ferr, 8124, "qh_settemppop: depth %d temp set %p of %d elements\n",
-       qh_setsize(qhmem.tempstack)+1, stackedset, qh_setsize(stackedset));
+       qh_setsize(qhmem.tempstack)+1, (void *) stackedset, qh_setsize(stackedset));
   return stackedset;
 } /* settemppop */
 
@@ -1295,7 +1295,7 @@ void qh_settemppush(setT *set) {
   qh_setappend(&qhmem.tempstack, set);
   if (qhmem.IStracing >= 5)
     qh_fprintf(qhmem.ferr, 8125, "qh_settemppush: depth %d temp set %p of %d elements\n",
-      qh_setsize(qhmem.tempstack), set, qh_setsize(set));
+      qh_setsize(qhmem.tempstack), (void *) set, qh_setsize(set));
 } /* settemppush */
 
 

--- a/src/libqhull_r/mem_r.c
+++ b/src/libqhull_r/mem_r.c
@@ -187,7 +187,7 @@ void qh_memcheck(qhT *qh) {
   }
   if (qh->qhmem.ferr == 0 || qh->qhmem.IStracing < 0 || qh->qhmem.IStracing > 10 || (((qh->qhmem.ALIGNmask+1) & qh->qhmem.ALIGNmask) != 0)) {
     qh_fprintf_stderr(6244, "qhull internal error (qh_memcheck): either qh->qhmem is overwritten or qh->qhmem is not initialized.  Call qh_meminit or qh_new_qhull before calling qh_mem routines.  ferr %p, IsTracing %d, ALIGNmask 0x%x\n",
-          qh->qhmem.ferr, qh->qhmem.IStracing, qh->qhmem.ALIGNmask);
+          (void *) qh->qhmem.ferr, qh->qhmem.IStracing, qh->qhmem.ALIGNmask);
     qh_exit(qhmem_ERRqhull);  /* can not use qh_errexit() */
   }
   if (qh->qhmem.IStracing != 0)

--- a/src/libqhull_r/merge_r.c
+++ b/src/libqhull_r/merge_r.c
@@ -428,7 +428,7 @@ void qh_appendmergeset(qhT *qh, facetT *facet, facetT *neighbor, mergeType merge
   }
   if (!qh->facet_mergeset || !qh->degen_mergeset) {
     qh_fprintf(qh, qh->ferr, 6403, "qhull internal error (qh_appendmergeset): expecting temp set defined for qh.facet_mergeset (%p) and qh.degen_mergeset (%p).  Got NULL\n",
-      qh->facet_mergeset, qh->degen_mergeset);
+      (void *) qh->facet_mergeset, (void *) qh->degen_mergeset);
     /* otherwise qh_setappend creates a new set that is not freed by qh_freebuild() */
     qh_errexit(qh, qh_ERRqhull, NULL, NULL);
   }
@@ -1654,7 +1654,7 @@ void qh_freemergesets(qhT *qh) {
 
   if (!qh->facet_mergeset || !qh->degen_mergeset || !qh->vertex_mergeset) {
     qh_fprintf(qh, qh->ferr, 6388, "qhull internal error (qh_freemergesets): expecting mergesets.  Got a NULL mergeset, qh.facet_mergeset (%p), qh.degen_mergeset (%p), qh.vertex_mergeset (%p)\n",
-      qh->facet_mergeset, qh->degen_mergeset, qh->vertex_mergeset);
+      (void *) qh->facet_mergeset, (void *) qh->degen_mergeset, (void *) qh->vertex_mergeset);
     qh_errexit(qh, qh_ERRqhull, NULL, NULL);
   }
   if (!SETempty_(qh->facet_mergeset) || !SETempty_(qh->degen_mergeset) || !SETempty_(qh->vertex_mergeset)) {
@@ -2034,7 +2034,7 @@ void qh_initmergesets(qhT *qh /* qh.facet_mergeset,degen_mergeset,vertex_mergese
 
   if (qh->facet_mergeset || qh->degen_mergeset || qh->vertex_mergeset) {
     qh_fprintf(qh, qh->ferr, 6386, "qhull internal error (qh_initmergesets): expecting NULL mergesets.  Got qh.facet_mergeset (%p), qh.degen_mergeset (%p), qh.vertex_mergeset (%p)\n",
-      qh->facet_mergeset, qh->degen_mergeset, qh->vertex_mergeset);
+      (void *) qh->facet_mergeset, (void *) qh->degen_mergeset, (void *) qh->vertex_mergeset);
     qh_errexit(qh, qh_ERRqhull, NULL, NULL);
   }
   qh->degen_mergeset= qh_settemp(qh, qh->TEMPsize);
@@ -3881,7 +3881,7 @@ void qh_mergevertex_neighbors(qhT *qh, facetT *facet1, facetT *facet2) {
           facet1->id, facet2->id));
   if (qh->tracevertex) {
     qh_fprintf(qh, qh->ferr, 8081, "qh_mergevertex_neighbors: of f%d into f%d at furthest p%d f0= %p\n",
-             facet1->id, facet2->id, qh->furthest_id, qh->tracevertex->neighbors->e[0].p);
+             facet1->id, facet2->id, qh->furthest_id, (void *) qh->tracevertex->neighbors->e[0].p);
     qh_errprint(qh, "TRACE", NULL, NULL, NULL, qh->tracevertex);
   }
   FOREACHvertex_(facet1->vertices) {

--- a/src/libqhull_r/poly2_r.c
+++ b/src/libqhull_r/poly2_r.c
@@ -1298,7 +1298,7 @@ void qh_checkpolygon(qhT *qh, facetT *facetlist) {
         numvertices++;
         if (qh_pointid(qh, vertex->point) == qh_IDunknown) {
           qh_fprintf(qh, qh->ferr, 6139, "qhull internal error (qh_checkpolygon): unknown point %p for vertex v%d first_point %p\n",
-                   vertex->point, vertex->id, qh->first_point);
+                   (void *) vertex->point, vertex->id, (void *) qh->first_point);
           waserror= True;
         }
       }
@@ -1406,7 +1406,7 @@ void qh_checkvertex(qhT *qh, vertexT *vertex, boolT allchecks, boolT *waserrorp)
   facetT *neighbor, **neighborp, *errfacet=NULL;
 
   if (qh_pointid(qh, vertex->point) == qh_IDunknown) {
-    qh_fprintf(qh, qh->ferr, 6144, "qhull internal error (qh_checkvertex): unknown point id %p\n", vertex->point);
+    qh_fprintf(qh, qh->ferr, 6144, "qhull internal error (qh_checkvertex): unknown point id %p\n", (void *) vertex->point);
     waserror= True;
   }
   if (vertex->id >= qh->vertex_id) {
@@ -3117,7 +3117,7 @@ void qh_point_add(qhT *qh, setT *set, pointT *point, void *elem) {
   SETreturnsize_(set, size);
   if ((id= qh_pointid(qh, point)) < 0)
     qh_fprintf(qh, qh->ferr, 7067, "qhull internal warning (point_add): unknown point %p id %d\n",
-      point, id);
+      (void *) point, id);
   else if (id >= size) {
     qh_fprintf(qh, qh->ferr, 6160, "qhull internal error (point_add): point p%d is out of bounds(%d)\n",
              id, size);

--- a/src/libqhull_r/qset_r.c
+++ b/src/libqhull_r/qset_r.c
@@ -1096,11 +1096,11 @@ void qh_setprint(qhT *qh, FILE *fp, const char* string, setT *set) {
   else {
     SETreturnsize_(set, size);
     qh_fprintf(qh, fp, 9347, "%s set=%p maxsize=%d size=%d elems=",
-             string, set, set->maxsize, size);
+             string, (void *) set, set->maxsize, size);
     if (size > set->maxsize)
       size= set->maxsize+1;
     for (k=0; k < size; k++)
-      qh_fprintf(qh, fp, 9348, " %p", set->e[k].p);
+      qh_fprintf(qh, fp, 9348, " %p", (void *) set->e[k].p);
     qh_fprintf(qh, fp, 9349, "\n");
   }
 } /* setprint */
@@ -1193,7 +1193,7 @@ setT *qh_settemp(qhT *qh, int setsize) {
   qh_setappend(qh, &qh->qhmem.tempstack, newset);
   if (qh->qhmem.IStracing >= 5)
     qh_fprintf(qh, qh->qhmem.ferr, 8123, "qh_settemp: temp set %p of %d elements, depth %d\n",
-       newset, newset->maxsize, qh_setsize(qh, qh->qhmem.tempstack));
+       (void *) newset, newset->maxsize, qh_setsize(qh, qh->qhmem.tempstack));
   return newset;
 } /* settemp */
 
@@ -1223,8 +1223,8 @@ void qh_settempfree(qhT *qh, setT **set) {
   if (stackedset != *set) {
     qh_settemppush(qh, stackedset);
     qh_fprintf(qh, qh->qhmem.ferr, 6179, "qhull internal error (qh_settempfree): set %p(size %d) was not last temporary allocated(depth %d, set %p, size %d)\n",
-             *set, qh_setsize(qh, *set), qh_setsize(qh, qh->qhmem.tempstack)+1,
-             stackedset, qh_setsize(qh, stackedset));
+             (void *) *set, qh_setsize(qh, *set), qh_setsize(qh, qh->qhmem.tempstack)+1,
+             (void *) stackedset, qh_setsize(qh, stackedset));
     qh_errexit(qh, qhmem_ERRqhull, NULL, NULL);
   }
   qh_setfree(qh, set);
@@ -1271,7 +1271,7 @@ setT *qh_settemppop(qhT *qh) {
   }
   if (qh->qhmem.IStracing >= 5)
     qh_fprintf(qh, qh->qhmem.ferr, 8124, "qh_settemppop: depth %d temp set %p of %d elements\n",
-       qh_setsize(qh, qh->qhmem.tempstack)+1, stackedset, qh_setsize(qh, stackedset));
+       qh_setsize(qh, qh->qhmem.tempstack)+1, (void *) stackedset, qh_setsize(qh, stackedset));
   return stackedset;
 } /* settemppop */
 
@@ -1295,7 +1295,7 @@ void qh_settemppush(qhT *qh, setT *set) {
   qh_setappend(qh, &qh->qhmem.tempstack, set);
   if (qh->qhmem.IStracing >= 5)
     qh_fprintf(qh, qh->qhmem.ferr, 8125, "qh_settemppush: depth %d temp set %p of %d elements\n",
-      qh_setsize(qh, qh->qhmem.tempstack), set, qh_setsize(qh, set));
+      qh_setsize(qh, qh->qhmem.tempstack), (void *) set, qh_setsize(qh, set));
 } /* settemppush */
 
 

--- a/src/testqset/testqset.c
+++ b/src/testqset/testqset.c
@@ -810,18 +810,18 @@ void checkSetContents(const char *name, setT *set, int count, int rangeA, int ra
         /* Must be first, otherwise trips msvc 8 */
         i2T **p= SETaddr_(set, i2T);
         if(*p!=SETfirstt_(set, i2T)){
-            qh_fprintf(stderr, 6309, "testqset (%s): SETaddr_(set, i2t) [%p] is not the same as SETfirst_(set) [%p]\n", name, SETaddr_(set, i2T), SETfirst_(set));
+            qh_fprintf(stderr, 6309, "testqset (%s): SETaddr_(set, i2t) [%p] is not the same as SETfirst_(set) [%p]\n", name, (void *) SETaddr_(set, i2T), (void *) SETfirst_(set));
             error_count++;
         }
         first= *(int *)SETfirst_(set);
         if(SETfirst_(set)!=SETfirstt_(set, i2T)){
-            qh_fprintf(stderr, 6308, "testqset (%s): SETfirst_(set) [%p] is not the same as SETfirstt_(set, i2T [%p]\n", name, SETfirst_(set), SETfirstt_(set, i2T));
+            qh_fprintf(stderr, 6308, "testqset (%s): SETfirst_(set) [%p] is not the same as SETfirstt_(set, i2T [%p]\n", name, (void *) SETfirst_(set), (void *) SETfirstt_(set, i2T));
             error_count++;
         }
         if(qh_setsize(set)>1){
             second= *(int *)SETsecond_(set);
             if(SETsecond_(set)!=SETsecondt_(set, i2T)){
-                qh_fprintf(stderr, 6310, "testqset (%s): SETsecond_(set) [%p] is not the same as SETsecondt_(set, i2T) [%p]\n", name, SETsecond_(set), SETsecondt_(set, i2T));
+                qh_fprintf(stderr, 6310, "testqset (%s): SETsecond_(set) [%p] is not the same as SETsecondt_(set, i2T) [%p]\n", name, (void *) SETsecond_(set), (void *) SETsecondt_(set, i2T));
                 error_count++;
             }
         }
@@ -838,7 +838,7 @@ void checkSetContents(const char *name, setT *set, int count, int rangeA, int ra
             error_count++;;
         }
         if(i2!=SETref_(i2)){
-            qh_fprintf(stderr, 6312, "testqset (%s): SETref_(i2) [%p] does not point to i2 (the %d'th element)\n", name, SETref_(i2), i);
+            qh_fprintf(stderr, 6312, "testqset (%s): SETref_(i2) [%p] does not point to i2 (the %d'th element)\n", name, (void *) SETref_(i2), i);
             error_count++;;
         }
         i++;
@@ -847,7 +847,7 @@ void checkSetContents(const char *name, setT *set, int count, int rangeA, int ra
         /* Must be first conditional, otherwise it trips up msvc 8 */
         i2T **p= SETelemaddr_(set, i2_i, i2T);
         if(i2!=*p){
-            qh_fprintf(stderr, 6320, "testqset (%s): SETelemaddr_(set, %d, i2T) [%p] does not point to i2\n", name, i2_i, SETelemaddr_(set, i2_i, int));
+            qh_fprintf(stderr, 6320, "testqset (%s): SETelemaddr_(set, %d, i2T) [%p] does not point to i2\n", name, i2_i, (void *) SETelemaddr_(set, i2_i, int));
             error_count++;;
         }
         if(i2_i==0){
@@ -884,7 +884,7 @@ void checkSetContents(const char *name, setT *set, int count, int rangeA, int ra
             }
         }
         if(i2!=SETelem_(set, i2_i)){
-            qh_fprintf(stderr, 6318, "testqset (%s): SETelem_(set, %d) [%p] is not i2 [%p] (the %d'th element)\n", name, i2_i, SETelem_(set, i2_i), i2, i2_i);
+            qh_fprintf(stderr, 6318, "testqset (%s): SETelem_(set, %d) [%p] is not i2 [%p] (the %d'th element)\n", name, i2_i, SETelem_(set, i2_i), (void *) i2, i2_i);
             error_count++;;
         }
         if(SETelemt_(set, i2_i, i2T)!=SETelem_(set, i2_i)){   /* Normally SETelemt_ is used for generic sets */

--- a/src/testqset_r/testqset_r.c
+++ b/src/testqset_r/testqset_r.c
@@ -786,7 +786,7 @@ void checkSetContents(qhT *qh, const char *name, setT *set, int count, int range
     if(set){
         SETreturnsize_(set, actualSize);  /* normally used only when speed is critical */
         if(*qh_setendpointer(set)!=NULL){
-            qh_fprintf(qh, stderr, 6344, "testqset_r (%s): qh_setendpointer(set), %p, is not NULL terminator of set %p\n", name, qh_setendpointer(set), set);
+            qh_fprintf(qh, stderr, 6344, "testqset_r (%s): qh_setendpointer(set), %p, is not NULL terminator of set %p\n", name, (void *) qh_setendpointer(set), (void *) set);
             error_count++;
         }
     }
@@ -806,18 +806,18 @@ void checkSetContents(qhT *qh, const char *name, setT *set, int count, int range
         /* Must be first, otherwise trips msvc 8 */
         i2T **p= SETaddr_(set, i2T);
         if(*p!=SETfirstt_(set, i2T)){
-            qh_fprintf(qh, stderr, 6309, "testqset_r (%s): SETaddr_(set, i2t) [%p] is not the same as SETfirst_(set) [%p]\n", name, SETaddr_(set, i2T), SETfirst_(set));
+            qh_fprintf(qh, stderr, 6309, "testqset_r (%s): SETaddr_(set, i2t) [%p] is not the same as SETfirst_(set) [%p]\n", name, (void *) SETaddr_(set, i2T), (void *) SETfirst_(set));
             error_count++;
         }
         first= *(int *)SETfirst_(set);
         if(SETfirst_(set)!=SETfirstt_(set, i2T)){
-            qh_fprintf(qh, stderr, 6308, "testqset_r (%s): SETfirst_(set) [%p] is not the same as SETfirstt_(set, i2T [%p]\n", name, SETfirst_(set), SETfirstt_(set, i2T));
+            qh_fprintf(qh, stderr, 6308, "testqset_r (%s): SETfirst_(set) [%p] is not the same as SETfirstt_(set, i2T [%p]\n", name, (void *) SETfirst_(set), (void *) SETfirstt_(set, i2T));
             error_count++;
         }
         if(qh_setsize(qh, set)>1){
             second= *(int *)SETsecond_(set);
             if(SETsecond_(set)!=SETsecondt_(set, i2T)){
-                qh_fprintf(qh, stderr, 6310, "testqset_r (%s): SETsecond_(set) [%p] is not the same as SETsecondt_(set, i2T) [%p]\n", name, SETsecond_(set), SETsecondt_(set, i2T));
+                qh_fprintf(qh, stderr, 6310, "testqset_r (%s): SETsecond_(set) [%p] is not the same as SETsecondt_(set, i2T) [%p]\n", name, (void *) SETsecond_(set), (void *) SETsecondt_(set, i2T));
                 error_count++;
             }
         }
@@ -834,7 +834,7 @@ void checkSetContents(qhT *qh, const char *name, setT *set, int count, int range
             error_count++;;
         }
         if(i2!=SETref_(i2)){
-            qh_fprintf(qh, stderr, 6312, "testqset_r (%s): SETref_(i2) [%p] does not point to i2 (the %d'th element)\n", name, SETref_(i2), i);
+            qh_fprintf(qh, stderr, 6312, "testqset_r (%s): SETref_(i2) [%p] does not point to i2 (the %d'th element)\n", name, (void *) SETref_(i2), i);
             error_count++;;
         }
         i++;
@@ -843,7 +843,7 @@ void checkSetContents(qhT *qh, const char *name, setT *set, int count, int range
         /* Must be first conditional, otherwise it trips up msvc 8 */
         i2T **p= SETelemaddr_(set, i2_i, i2T);
         if(i2!=*p){
-            qh_fprintf(qh, stderr, 6320, "testqset_r (%s): SETelemaddr_(set, %d, i2T) [%p] does not point to i2\n", name, i2_i, SETelemaddr_(set, i2_i, int));
+            qh_fprintf(qh, stderr, 6320, "testqset_r (%s): SETelemaddr_(set, %d, i2T) [%p] does not point to i2\n", name, i2_i, (void *) SETelemaddr_(set, i2_i, int));
             error_count++;;
         }
         if(i2_i==0){
@@ -880,11 +880,11 @@ void checkSetContents(qhT *qh, const char *name, setT *set, int count, int range
             }
         }
         if(i2!=SETelem_(set, i2_i)){
-            qh_fprintf(qh, stderr, 6318, "testqset_r (%s): SETelem_(set, %d) [%p] is not i2 [%p] (the %d'th element)\n", name, i2_i, SETelem_(set, i2_i), i2, i2_i);
+            qh_fprintf(qh, stderr, 6318, "testqset_r (%s): SETelem_(set, %d) [%p] is not i2 [%p] (the %d'th element)\n", name, i2_i, (void *) SETelem_(set, i2_i), (void *) i2, i2_i);
             error_count++;;
         }
         if(SETelemt_(set, i2_i, i2T)!=SETelem_(set, i2_i)){   /* Normally SETelemt_ is used for generic sets */
-            qh_fprintf(qh, stderr, 6319, "testqset_r (%s): SETelemt_(set, %d, i2T) [%p] is not SETelem_(set, %d) [%p] (the %d'th element)\n", name, i2_i, SETelemt_(set, i2_i, int), i2_i, SETelem_(set, i2_i), i2_i);
+            qh_fprintf(qh, stderr, 6319, "testqset_r (%s): SETelemt_(set, %d, i2T) [%p] is not SETelem_(set, %d) [%p] (the %d'th element)\n", name, i2_i, (void *) SETelemt_(set, i2_i, int), i2_i, SETelem_(set, i2_i), i2_i);
             error_count++;;
         }
     }


### PR DESCRIPTION
Apparently, if we're strict, the C standard only allows `void *` with the `%p` format specifier (even though on most platforms, passing an object pointer is fine).

This is a followup on #143 that fixes this and reduces the amount of compiler warnings at higher warning levels.

How to test this PR? Compile with Clang (or perhaps GCC) using `-Wpedantic`, and the compiler will be strict in in checking printf format specifiers.