### PR TITLE
feat: QH_NORETURN macro to set noreturn function attribute

### DIFF
--- a/src/libqhull/libqhull.h
+++ b/src/libqhull/libqhull.h
@@ -67,6 +67,19 @@
 #define QH_PRINTF_LIKE(string_index, first_to_check)
 #endif
 
+/* QH_NORETURN marks as a function as never returning. This is primarily
+   beneficial for aiding static analyzers and reducing compiler warnings.
+   It must come before function declarations, as MSVC only supports this syntax. */
+#if defined(__GNUC__)
+/* Compilers that support the GNU C syntax. Use __noreturn__ instead of 'noreturn' as the latter is a macro in C11. */
+#define QH_NORETURN __attribute__((__noreturn__))
+#elif defined(_MSC_VER)
+/* Compilers that support the MSVC syntax. */
+#define QH_NORETURN __declspec(noreturn)
+#else
+#define QH_NORETURN /* empty */
+#endif
+
 /*============ constants and basic types ====================*/
 
 extern const char qh_version[]; /* defined in global.c */
@@ -1123,12 +1136,12 @@ struct qhT {
 
 void    qh_qhull(void);
 boolT   qh_addpoint(pointT *furthest, facetT *facet, boolT checkdist);
-void    qh_errexit2(int exitcode, facetT *facet, facetT *otherfacet);
+void    QH_NORETURN qh_errexit2(int exitcode, facetT *facet, facetT *otherfacet);
 void    qh_printsummary(FILE *fp);
 
 /********* -user.c prototypes (alphabetical) **********************/
 
-void    qh_errexit(int exitcode, facetT *facet, ridgeT *ridge);
+void    QH_NORETURN qh_errexit(int exitcode, facetT *facet, ridgeT *ridge);
 void    qh_errprint(const char* string, facetT *atfacet, facetT *otherfacet, ridgeT *atridge, vertexT *atvertex);
 int     qh_new_qhull(int dim, int numpoints, coordT *points, boolT ismalloc,
                 char *qhull_cmd, FILE *outfile, FILE *errfile);
@@ -1142,7 +1155,7 @@ void    qh_printhelp_wide(FILE *fp);
 void    qh_user_memsizes(void);
 
 /********* -usermem.c prototypes (alphabetical) **********************/
-void    qh_exit(int exitcode);
+void    QH_NORETURN qh_exit(int exitcode);
 void    qh_fprintf_stderr(int msgcode, const char *fmt, ... ) QH_PRINTF_LIKE(2, 3);
 void    qh_free(void *mem);
 void   *qh_malloc(size_t size);
@@ -1226,7 +1239,7 @@ void    qh_triangulate(void /* qh.facet_list */);
 
 /********* -rboxlib.c prototypes **********************/
 int     qh_rboxpoints(FILE* fout, FILE* ferr, char* rbox_command);
-void    qh_errexit_rbox(int exitcode);
+void    QH_NORETURN qh_errexit_rbox(int exitcode);
 
 /********* -stat.c prototypes (duplicated from stat.h) **********************/
 

--- a/src/libqhull_r/libqhull_r.h
+++ b/src/libqhull_r/libqhull_r.h
@@ -55,6 +55,19 @@
 #define QH_PRINTF_LIKE(string_index, first_to_check)
 #endif
 
+/* QH_NORETURN marks as a function as never returning. This is primarily
+   beneficial for aiding static analyzers and reducing compiler warnings.
+   It must come before function declarations, as MSVC only supports this syntax. */
+#if defined(__GNUC__)
+/* Compilers that support the GNU C syntax. Use __noreturn__ instead of 'noreturn' as the latter is a macro in C11. */
+#define QH_NORETURN __attribute__((__noreturn__))
+#elif defined(_MSC_VER)
+/* Compilers that support the MSVC syntax. */
+#define QH_NORETURN __declspec(noreturn)
+#else
+#define QH_NORETURN /* empty */
+#endif
+
 /*============ constants and basic types ====================*/
 
 extern const char qh_version[]; /* defined in global_r.c */
@@ -1119,12 +1132,12 @@ extern "C" {
 
 void    qh_qhull(qhT *qh);
 boolT   qh_addpoint(qhT *qh, pointT *furthest, facetT *facet, boolT checkdist);
-void    qh_errexit2(qhT *qh, int exitcode, facetT *facet, facetT *otherfacet);
+void    QH_NORETURN qh_errexit2(qhT *qh, int exitcode, facetT *facet, facetT *otherfacet);
 void    qh_printsummary(qhT *qh, FILE *fp);
 
 /********* -user_r.c prototypes (alphabetical) **********************/
 
-void    qh_errexit(qhT *qh, int exitcode, facetT *facet, ridgeT *ridge);
+void    QH_NORETURN qh_errexit(qhT *qh, int exitcode, facetT *facet, ridgeT *ridge);
 void    qh_errprint(qhT *qh, const char* string, facetT *atfacet, facetT *otherfacet, ridgeT *atridge, vertexT *atvertex);
 int     qh_new_qhull(qhT *qh, int dim, int numpoints, coordT *points, boolT ismalloc,
                 char *qhull_cmd, FILE *outfile, FILE *errfile);
@@ -1138,7 +1151,7 @@ void    qh_printhelp_wide(qhT *qh, FILE *fp);
 void    qh_user_memsizes(qhT *qh);
 
 /********* -usermem_r.c prototypes (alphabetical) **********************/
-void    qh_exit(int exitcode);
+void    QH_NORETURN qh_exit(int exitcode);
 void    qh_fprintf_stderr(int msgcode, const char *fmt, ... ) QH_PRINTF_LIKE(2, 3);
 void    qh_free(void *mem);
 void   *qh_malloc(size_t size);
@@ -1212,7 +1225,7 @@ void    qh_triangulate(qhT *qh /* qh.facet_list */);
 
 /********* -rboxlib_r.c prototypes **********************/
 int     qh_rboxpoints(qhT *qh, char* rbox_command);
-void    qh_errexit_rbox(qhT *qh, int exitcode);
+void    QH_NORETURN qh_errexit_rbox(qhT *qh, int exitcode);
 
 /************************** accessors.c prototypes ******************************/
 


### PR DESCRIPTION
This PR adds the `QH_NORETURN` macro to set a "noreturn" function attribute. This is in the spirit of the recently added `QH_PRINTF_LIKE`, but note that it supports MSVC, which means that it is not allowed _after_ the function declaration, only before.

There is no standard way to do this in C99, so it uses GCC and MSVC specific features.

The main benefit here is to improve warnings from compilers and static analyzers (as well as theoretically slightly better compiler optimizations). With igraph, we use https://scan.coverity.com/ which is generally very helpful, but started to generate a huge number of warnings for the Qhull code. I expect a large fraction will be fixed by this. Of course this is not critical to fix, but it is helpful.

EDIT: This fixed 7 out of 35 issues found by Coverity. I'm happy to share the rest of the issues, but note that there tends to be many false positives and it usually takes quite the effort to sort through them. I'm not sure that this is a good idea to do at this stage.